### PR TITLE
Adds possibility to set up custom exception formatter.

### DIFF
--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetExtensions.cs
@@ -1,10 +1,30 @@
 ﻿namespace Microsoft.Extensions.Logging
 {
+    using System;
+
     /// <summary>
     /// The log4net extensions class.
     /// </summary>
     public static class Log4NetExtensions
     {
+        /// <summary>
+        /// The default log4net config file name.
+        /// </summary>
+        private const string DefaultLog4NetConfigFile = "log4net.config";
+
+        /// <summary>
+        /// Adds the log4net.
+        /// </summary>
+        /// <param name="factory">The factory.</param>
+        /// <param name="log4NetConfigFile">The log4net Config File.</param>
+        /// <returns>The <see cref="ILoggerFactory"/>.</returns>
+        public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, string log4NetConfigFile, Func<object, Exception, string> exceptionFormatter)
+        {
+            Log4NetProvider provider = new Log4NetProvider(log4NetConfigFile, exceptionFormatter);
+            factory.AddProvider(provider);
+            return factory;
+        }
+
         /// <summary>
         /// Adds the log4net.
         /// </summary>
@@ -13,7 +33,19 @@
         /// <returns>The <see cref="ILoggerFactory"/>.</returns>
         public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, string log4NetConfigFile)
         {
-            factory.AddProvider(new Log4NetProvider(log4NetConfigFile));
+            factory.AddProvider(new Log4NetProvider(log4NetConfigFile, null));
+            return factory;
+        }
+
+        /// <summary>
+        /// Adds the log4net.
+        /// </summary>
+        /// <param name="factory">The factory.</param>
+        /// <param name="exceptionFormatter">The exception formatter.</param>
+        /// <returns>The <see cref="ILoggerFactory"/>.</returns>
+        public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, Func<object, Exception, string> exceptionFormatter)
+        {
+            factory.AddLog4Net(DefaultLog4NetConfigFile, exceptionFormatter);
             return factory;
         }
 
@@ -24,7 +56,7 @@
         /// <returns>The <see cref="ILoggerFactory"/>.</returns>
         public static ILoggerFactory AddLog4Net(this ILoggerFactory factory)
         {
-            factory.AddLog4Net("log4net.config");
+            factory.AddLog4Net(DefaultLog4NetConfigFile, null);
             return factory;
         }
     }

--- a/src/Microsoft.Extensions.Logging.Log4net.sln
+++ b/src/Microsoft.Extensions.Logging.Log4net.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.15
+VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Logging.Log4Net.AspNetCore", "Microsoft.Extensions.Logging.Log4Net.AspNetCore\Microsoft.Extensions.Logging.Log4Net.AspNetCore.csproj", "{A2F0571A-E90E-4030-B05E-531A4CDE084D}"
 EndProject
@@ -18,5 +18,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8E3DFD5E-550F-4D27-BD8A-49D16DD84DB9}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
As @georgechr indicates on #1  issue, the default behavior of any logger in
https://github.com/aspnet/Logging/blob/dev/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
is to ignore the exception content itself.

From now, the **_AddLog4Net()_** method allow the user to set up, as
parameter, the formatting style **_Func<>_** that will be used when a message
with exception was logged.

But, if the user does not configure anything to format the exception,
the process takes a default one, that concatenates the State with the
Message of the given exception.

This commit resolves #1 issue