### PR TITLE
Remove build status as CI appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Allows to configure Log4net as Microsoft Extensions Logging handler on any ASP.N
 
 Thanks to [@anuraj](https://github.com/anuraj) for this [original blog post](https://dotnetthoughts.net/how-to-use-log4net-with-aspnetcore-for-logging/).
 
-[![Build status](https://ci.appveyor.com/api/projects/status/nbjg1uhi3aqma5ft/branch/master?svg=true)](https://ci.appveyor.com/project/huorswords/microsoft-extensions-logging-log4net-aspnetcore/branch/master) [![NuGet](https://img.shields.io/nuget/dt/Microsoft.Extensions.Logging.Log4net.AspNetCore.svg)](https://preview.nuget.org/packages/Microsoft.Extensions.Logging.Log4Net.AspNetCore/)
+[![NuGet](https://img.shields.io/nuget/dt/Microsoft.Extensions.Logging.Log4net.AspNetCore.svg)](https://preview.nuget.org/packages/Microsoft.Extensions.Logging.Log4Net.AspNetCore/)
 
 ## Example of use
 


### PR DESCRIPTION
As .NET Core apps are not able to be build on appveyor (or I don't know how), I remove the badge in order to be honest with possible users.