### PR TITLE
Changed Net Core configuration section structure.

### DIFF
--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Entities/NodeInfo.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Entities/NodeInfo.cs
@@ -1,38 +1,36 @@
 ﻿namespace Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities
 {
-	using System;
-	using System.Collections.Generic;
-	using System.Text;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
 
-	/// <summary>
-	///  Class to store information of a log4net xml config file node.
-	/// </summary>
-	public class NodeInfo
-	{
+    /// <summary>
+    ///  Class to store information of a log4net xml config file node.
+    /// </summary>
+    public class NodeInfo
+    {
+        /// <summary>
+        /// Gets or sets the x path to find the node to override.
+        /// </summary>
+        /// <value>
+        /// The x path.
+        /// </value>
+        public string XPath { get; set; }
 
-		/// <summary>
-		/// Gets or sets the x path to find the node to override.
-		/// </summary>
-		/// <value>
-		/// The x path.
-		/// </value>
-		public string XPath { get; set; }
+        /// <summary>
+        /// Gets or sets the content of the node.
+        /// </summary>
+        /// <value>
+        /// The content of the node.
+        /// </value>
+        public string NodeContent { get; set; }
 
-
-		/// <summary>
-		/// Gets or sets the content of the node.
-		/// </summary>
-		/// <value>
-		/// The content of the node.
-		/// </value>
-		public string NodeContent { get; set; }
-
-		/// <summary>
-		/// Gets or sets the attributes.
-		/// </summary>
-		/// <value>
-		/// The attributes.
-		/// </value>
-		public Dictionary<string, string> Attributes { get; set; }
-	}
+        /// <summary>
+        /// Gets or sets the attributes.
+        /// </summary>
+        /// <value>
+        /// The attributes.
+        /// </value>
+        public Dictionary<string, string> Attributes { get; set; }
+    }
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Entities/NodeInfo.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Entities/NodeInfo.cs
@@ -1,28 +1,38 @@
 ﻿namespace Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
+	using System;
+	using System.Collections.Generic;
+	using System.Text;
 
-    /// <summary>
-    ///  Class to store information of a log4net xml config file node.
-    /// </summary>
-    public class NodeInfo
-    {
-        /// <summary>
-        /// Gets or sets the content of the node.
-        /// </summary>
-        /// <value>
-        /// The content of the node.
-        /// </value>
-        public string NodeContent { get; set; }
+	/// <summary>
+	///  Class to store information of a log4net xml config file node.
+	/// </summary>
+	public class NodeInfo
+	{
 
-        /// <summary>
-        /// Gets or sets the attributes.
-        /// </summary>
-        /// <value>
-        /// The attributes.
-        /// </value>
-        public Dictionary<string, string> Attributes { get; set; }
-    }
+		/// <summary>
+		/// Gets or sets the x path to find the node to override.
+		/// </summary>
+		/// <value>
+		/// The x path.
+		/// </value>
+		public string XPath { get; set; }
+
+
+		/// <summary>
+		/// Gets or sets the content of the node.
+		/// </summary>
+		/// <value>
+		/// The content of the node.
+		/// </value>
+		public string NodeContent { get; set; }
+
+		/// <summary>
+		/// Gets or sets the attributes.
+		/// </summary>
+		/// <value>
+		/// The attributes.
+		/// </value>
+		public Dictionary<string, string> Attributes { get; set; }
+	}
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Extensions/IConfigurationSectionExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Extensions/IConfigurationSectionExtensions.cs
@@ -15,7 +15,7 @@
         /// <param name="configurationSection">The configuration section.</param>
         /// <returns>The dictionary</returns>
         /// <exception cref="ArgumentNullException">Throws if <paramref name="configurationSection"/> is null.</exception>
-        public static IEnumerable<NodeInfo> ConvertToNodesInfo(this IConfigurationSection configurationSection)=>
+        public static IEnumerable<NodeInfo> ConvertToNodesInfo(this IConfigurationSection configurationSection) =>
             configurationSection.Get<IEnumerable<NodeInfo>>();
     }
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Extensions/IConfigurationSectionExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Extensions/IConfigurationSectionExtensions.cs
@@ -15,7 +15,7 @@
         /// <param name="configurationSection">The configuration section.</param>
         /// <returns>The dictionary</returns>
         /// <exception cref="ArgumentNullException">Throws if <paramref name="configurationSection"/> is null.</exception>
-        public static IDictionary<string, NodeInfo> ConvertToDictionary(this IConfigurationSection configurationSection) =>
-            configurationSection.Get<Dictionary<string, NodeInfo>>();
+        public static IEnumerable<NodeInfo> ConvertToNodesInfo(this IConfigurationSection configurationSection)=>
+            configurationSection.Get<IEnumerable<NodeInfo>>();
     }
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetExtensions.cs
@@ -1,69 +1,69 @@
 ﻿namespace Microsoft.Extensions.Logging
 {
-	using Microsoft.Extensions.Configuration;
-	using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
 
-	/// <summary>
-	/// The log4net extensions class.
-	/// </summary>
-	public static class Log4NetExtensions
-	{
-		/// <summary>
-		/// The default log4net config file name.
-		/// </summary>
-		private const string DefaultLog4NetConfigFile = "log4net.config";
+    /// <summary>
+    /// The log4net extensions class.
+    /// </summary>
+    public static class Log4NetExtensions
+    {
+        /// <summary>
+        /// The default log4net config file name.
+        /// </summary>
+        private const string DefaultLog4NetConfigFile = "log4net.config";
 
-		/// <summary>
-		/// Adds the log4 net.
-		/// </summary>
-		/// <param name="factory">The factory.</param>
-		/// <param name="log4NetConfigFile">The log4 net configuration file.</param>
-		/// <param name="watch">if set to <c>true</c> [watch].</param>
-		/// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
-		public static ILoggerFactory AddLog4Net(
-			this ILoggerFactory factory,
-			string log4NetConfigFile,
-			bool watch)
-		{
-			factory.AddProvider(new Log4NetProvider(log4NetConfigFile, watch));
-			return factory;
-		}
+        /// <summary>
+        /// Adds the log4 net.
+        /// </summary>
+        /// <param name="factory">The factory.</param>
+        /// <param name="log4NetConfigFile">The log4 net configuration file.</param>
+        /// <param name="watch">if set to <c>true</c> [watch].</param>
+        /// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
+        public static ILoggerFactory AddLog4Net(
+            this ILoggerFactory factory,
+            string log4NetConfigFile,
+            bool watch)
+        {
+            factory.AddProvider(new Log4NetProvider(log4NetConfigFile, watch));
+            return factory;
+        }
 
-		/// <summary>
-		/// Adds the log4net.
-		/// </summary>
-		/// <param name="factory">The factory.</param>
-		/// <param name="log4NetConfigFile">The log4 net configuration file.</param>
-		/// <param name="configurationSection">The configuration section.</param>
-		/// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
-		public static ILoggerFactory AddLog4Net(
-			this ILoggerFactory factory,
-			string log4NetConfigFile,
-			IConfigurationSection configurationSection)
-		{
-			factory.AddProvider(new Log4NetProvider(log4NetConfigFile, configurationSection));
-			return factory;
-		}
+        /// <summary>
+        /// Adds the log4net.
+        /// </summary>
+        /// <param name="factory">The factory.</param>
+        /// <param name="log4NetConfigFile">The log4 net configuration file.</param>
+        /// <param name="configurationSection">The configuration section.</param>
+        /// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
+        public static ILoggerFactory AddLog4Net(
+            this ILoggerFactory factory,
+            string log4NetConfigFile,
+            IConfigurationSection configurationSection)
+        {
+            factory.AddProvider(new Log4NetProvider(log4NetConfigFile, configurationSection));
+            return factory;
+        }
 
-		/// <summary>
-		/// Adds the log4net.
-		/// </summary>
-		/// <param name="factory">The factory.</param>
-		/// <param name="log4NetConfigFile">The log4net Config File.</param>
-		/// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
-		public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, string log4NetConfigFile) =>
-			factory.AddLog4Net(log4NetConfigFile, false);
+        /// <summary>
+        /// Adds the log4net.
+        /// </summary>
+        /// <param name="factory">The factory.</param>
+        /// <param name="log4NetConfigFile">The log4net Config File.</param>
+        /// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
+        public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, string log4NetConfigFile) =>
+            factory.AddLog4Net(log4NetConfigFile, false);
 
-		/// <summary>
-		/// Adds the log4net.
-		/// </summary>
-		/// <param name="factory">The factory.</param>
-		/// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
-		public static ILoggerFactory AddLog4Net(this ILoggerFactory factory)
-		{
-			factory.AddLog4Net(DefaultLog4NetConfigFile);
-			return factory;
-		}
+        /// <summary>
+        /// Adds the log4net.
+        /// </summary>
+        /// <param name="factory">The factory.</param>
+        /// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
+        public static ILoggerFactory AddLog4Net(this ILoggerFactory factory)
+        {
+            factory.AddLog4Net(DefaultLog4NetConfigFile);
+            return factory;
+        }
 
 #if !NETCOREAPP1_1
         /// <summary>
@@ -119,5 +119,5 @@
             return builder; 
         }
 #endif
-	}
+    }
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetLogger.cs
@@ -1,48 +1,48 @@
 ﻿namespace Microsoft.Extensions.Logging
 {
-	using System;
+    using System;
 
-	using log4net;
+    using log4net;
 
-	/// <summary>
-	/// The log4net logger class.
-	/// </summary>
-	public class Log4NetLogger : ILogger
-	{
-		/// <summary>
-		/// The log.
-		/// </summary>
-		private readonly ILog log;
+    /// <summary>
+    /// The log4net logger class.
+    /// </summary>
+    public class Log4NetLogger : ILogger
+    {
+        /// <summary>
+        /// The log.
+        /// </summary>
+        private readonly ILog log;
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="Log4NetLogger"/> class.
-		/// </summary>
-		/// <param name="loggerRepository">The repository name.</param>
-		/// <param name="name">The logger's name.</param>
-		public Log4NetLogger(string loggerRepository, string name) 
-			=> this.log = LogManager.GetLogger(loggerRepository, name);
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log4NetLogger"/> class.
+        /// </summary>
+        /// <param name="loggerRepository">The repository name.</param>
+        /// <param name="name">The logger's name.</param>
+        public Log4NetLogger(string loggerRepository, string name) 
+            => this.log = LogManager.GetLogger(loggerRepository, name);
 
-		/// <summary>
-		/// Gets the name.
-		/// </summary>
-		public string Name
-		{
-			get
-			{
-				return this.log.Logger.Name;
-			}
-		}
+        /// <summary>
+        /// Gets the name.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                return this.log.Logger.Name;
+            }
+        }
 
-		/// <summary>
-		/// Begins a logical operation scope.
-		/// </summary>
-		/// <typeparam name="TState">The type of the state.</typeparam>
-		/// <param name="state">The identifier for the scope.</param>
-		/// <returns>
-		/// An IDisposable that ends the logical operation scope on dispose.
-		/// </returns>
-		public IDisposable BeginScope<TState>(TState state) 
-			=> null;
+        /// <summary>
+        /// Begins a logical operation scope.
+        /// </summary>
+        /// <typeparam name="TState">The type of the state.</typeparam>
+        /// <param name="state">The identifier for the scope.</param>
+        /// <returns>
+        /// An IDisposable that ends the logical operation scope on dispose.
+        /// </returns>
+        public IDisposable BeginScope<TState>(TState state) 
+            => null;
 
         /// <summary>
         /// Determines whether the logging level is enabled.
@@ -70,27 +70,27 @@
             }
         }
 
-		/// <summary>
-		/// Logs an exception into the log.
-		/// </summary>
-		/// <param name="logLevel">The log level.</param>
-		/// <param name="eventId">The event Id.</param>
-		/// <param name="state">The state.</param>
-		/// <param name="exception">The exception.</param>
-		/// <param name="formatter">The formatter.</param>
-		/// <typeparam name="TState">The type of the state.</typeparam>
-		/// <exception cref="ArgumentNullException">Throws when the <paramref name="formatter"/> is null.</exception>
-		public void Log<TState>(
-			LogLevel logLevel,
-			EventId eventId,
-			TState state,
-			Exception exception,
-			Func<TState, Exception, string> formatter)
-		{
-			if (!this.IsEnabled(logLevel))
-			{
-				return;
-			}
+        /// <summary>
+        /// Logs an exception into the log.
+        /// </summary>
+        /// <param name="logLevel">The log level.</param>
+        /// <param name="eventId">The event Id.</param>
+        /// <param name="state">The state.</param>
+        /// <param name="exception">The exception.</param>
+        /// <param name="formatter">The formatter.</param>
+        /// <typeparam name="TState">The type of the state.</typeparam>
+        /// <exception cref="ArgumentNullException">Throws when the <paramref name="formatter"/> is null.</exception>
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception exception,
+            Func<TState, Exception, string> formatter)
+        {
+            if (!this.IsEnabled(logLevel))
+            {
+                return;
+            }
 
             if (formatter == null)
             {

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
@@ -8,20 +8,24 @@
     using System.Xml.Linq;
     using System.Xml.XPath;
 
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
-    using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Extensions;
-
     using log4net;
     using log4net.Config;
     using log4net.Repository;
-
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
+    using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Extensions;
+    
     /// <summary>
     /// The log4net provider class.
     /// </summary>
     /// <seealso cref="Microsoft.Extensions.Logging.ILoggerProvider" />
     public class Log4NetProvider : ILoggerProvider
     {
+        /// <summary>
+        /// The default log4 net file name
+        /// </summary>
+        private const string DefaultLog4NetFileName = "log4net.config";
+
         /// <summary>
         /// The log4net repository.
         /// </summary>
@@ -31,8 +35,6 @@
         /// The loggers collection.
         /// </summary>
         private readonly ConcurrentDictionary<string, Log4NetLogger> loggers = new ConcurrentDictionary<string, Log4NetLogger>();
-
-        private const string DefaultLog4NetFileName = "log4net.config";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Log4NetProvider"/> class.

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
@@ -1,222 +1,221 @@
 ﻿namespace Microsoft.Extensions.Logging
 {
-	using System;
-	using System.Collections.Concurrent;
-	using System.IO;
-	using System.Reflection;
-	using System.Xml;
-	using System.Xml.Linq;
-	using System.Xml.XPath;
+    using System;
+    using System.Collections.Concurrent;
+    using System.IO;
+    using System.Reflection;
+    using System.Xml;
+    using System.Xml.Linq;
+    using System.Xml.XPath;
 
-	using Microsoft.Extensions.Configuration;
-	using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
-	using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Extensions;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
+    using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Extensions;
 
-	using log4net;
-	using log4net.Config;
-	using log4net.Repository;
+    using log4net;
+    using log4net.Config;
+    using log4net.Repository;
 
-	/// <summary>
-	/// The log4net provider class.
-	/// </summary>
-	/// <seealso cref="Microsoft.Extensions.Logging.ILoggerProvider" />
-	public class Log4NetProvider : ILoggerProvider
-	{
-		/// <summary>
-		/// The log4net repository.
-		/// </summary>
-		private readonly ILoggerRepository loggerRepository;
+    /// <summary>
+    /// The log4net provider class.
+    /// </summary>
+    /// <seealso cref="Microsoft.Extensions.Logging.ILoggerProvider" />
+    public class Log4NetProvider : ILoggerProvider
+    {
+        /// <summary>
+        /// The log4net repository.
+        /// </summary>
+        private readonly ILoggerRepository loggerRepository;
 
-		/// <summary>
-		/// The loggers collection.
-		/// </summary>
-		private readonly ConcurrentDictionary<string, Log4NetLogger> loggers = new ConcurrentDictionary<string, Log4NetLogger>();
+        /// <summary>
+        /// The loggers collection.
+        /// </summary>
+        private readonly ConcurrentDictionary<string, Log4NetLogger> loggers = new ConcurrentDictionary<string, Log4NetLogger>();
 
-		private const string DefaultLog4NetFileName = "log4net.config";
+        private const string DefaultLog4NetFileName = "log4net.config";
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="Log4NetProvider"/> class.
-		/// </summary>
-		public Log4NetProvider()
-			: this(DefaultLog4NetFileName)
-		{
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log4NetProvider"/> class.
+        /// </summary>
+        public Log4NetProvider()
+            : this(DefaultLog4NetFileName)
+        {
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="Log4NetProvider"/> class.
-		/// </summary>
-		/// <param name="log4NetConfigFile">The log4NetConfigFile.</param>
-		public Log4NetProvider(string log4NetConfigFile)
-			: this(log4NetConfigFile, false, null)
-		{
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log4NetProvider"/> class.
+        /// </summary>
+        /// <param name="log4NetConfigFile">The log4NetConfigFile.</param>
+        public Log4NetProvider(string log4NetConfigFile)
+            : this(log4NetConfigFile, false, null)
+        {
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="Log4NetProvider"/> class.
-		/// </summary>
-		/// <param name="log4NetConfigFile">The log4 net configuration file.</param>
-		/// <param name="configurationSection">The configuration section.</param>
-		public Log4NetProvider(string log4NetConfigFile, IConfigurationSection configurationSection)
-			: this(log4NetConfigFile, false, configurationSection)
-		{
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log4NetProvider"/> class.
+        /// </summary>
+        /// <param name="log4NetConfigFile">The log4 net configuration file.</param>
+        /// <param name="configurationSection">The configuration section.</param>
+        public Log4NetProvider(string log4NetConfigFile, IConfigurationSection configurationSection)
+            : this(log4NetConfigFile, false, configurationSection)
+        {
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="Log4NetProvider"/> class.
-		/// </summary>
-		/// <param name="log4NetConfigFile">The log4 net configuration file.</param>
-		/// <param name="watch">if set to <c>true</c> [watch].</param>
-		public Log4NetProvider(string log4NetConfigFile, bool watch)
-			: this(log4NetConfigFile, watch, null)
-		{
-		}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log4NetProvider"/> class.
+        /// </summary>
+        /// <param name="log4NetConfigFile">The log4 net configuration file.</param>
+        /// <param name="watch">if set to <c>true</c> [watch].</param>
+        public Log4NetProvider(string log4NetConfigFile, bool watch)
+            : this(log4NetConfigFile, watch, null)
+        {
+        }
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="Log4NetProvider" /> class.
-		/// </summary>
-		/// <param name="log4NetConfigFile">The log4 net configuration file.</param>
-		/// <param name="watch">if set to <c>true</c> [watch].</param>
-		/// <param name="configurationSection">The configuration section.</param>
-		/// <exception cref="NotSupportedException">Watch cannot be true if you are overwriting config file values with values from configuration section.</exception>
-		private Log4NetProvider(string log4NetConfigFile, bool watch, IConfigurationSection configurationSection)
-		{
-			if (watch && configurationSection != null)
-			{
-				throw new NotSupportedException("Wach cannot be true if you are overwriting config file values with values from configuration section.");
-			}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log4NetProvider" /> class.
+        /// </summary>
+        /// <param name="log4NetConfigFile">The log4 net configuration file.</param>
+        /// <param name="watch">if set to <c>true</c> [watch].</param>
+        /// <param name="configurationSection">The configuration section.</param>
+        /// <exception cref="NotSupportedException">Watch cannot be true if you are overwriting config file values with values from configuration section.</exception>
+        private Log4NetProvider(string log4NetConfigFile, bool watch, IConfigurationSection configurationSection)
+        {
+            if (watch && configurationSection != null)
+            {
+                throw new NotSupportedException("Wach cannot be true if you are overwriting config file values with values from configuration section.");
+            }
 
-			this.loggerRepository = LogManager.CreateRepository(
-				Assembly.GetEntryAssembly() ?? GetCallingAssemblyFromStartup(),
-				typeof(log4net.Repository.Hierarchy.Hierarchy));
+            this.loggerRepository = LogManager.CreateRepository(
+                Assembly.GetEntryAssembly() ?? GetCallingAssemblyFromStartup(),
+                typeof(log4net.Repository.Hierarchy.Hierarchy));
 
-			if (watch)
-			{
-				XmlConfigurator.ConfigureAndWatch(this.loggerRepository, new FileInfo(Path.GetFullPath(log4NetConfigFile)));
-			}
-			else
-			{
-				var configXml = ParseLog4NetConfigFile(log4NetConfigFile);
-				if (configurationSection != null)
-				{
-					configXml = UpdateNodesWithAdditionalConfiguration(configXml, configurationSection);
-				}
+            if (watch)
+            {
+                XmlConfigurator.ConfigureAndWatch(this.loggerRepository, new FileInfo(Path.GetFullPath(log4NetConfigFile)));
+            }
+            else
+            {
+                var configXml = ParseLog4NetConfigFile(log4NetConfigFile);
+                if (configurationSection != null)
+                {
+                    configXml = UpdateNodesWithAdditionalConfiguration(configXml, configurationSection);
+                }
 
-				XmlConfigurator.Configure(this.loggerRepository, configXml.DocumentElement);
-			}
-		}
+                XmlConfigurator.Configure(this.loggerRepository, configXml.DocumentElement);
+            }
+        }
 
-		/// <summary>
-		/// Creates the logger.
-		/// </summary>
-		/// <param name="categoryName">The category name.</param>
-		/// <returns>The <see cref="ILogger"/> instance.</returns>
-		public ILogger CreateLogger(string categoryName)
-				=> this.loggers.GetOrAdd(categoryName, this.CreateLoggerImplementation);
+        /// <summary>
+        /// Creates the logger.
+        /// </summary>
+        /// <param name="categoryName">The category name.</param>
+        /// <returns>The <see cref="ILogger"/> instance.</returns>
+        public ILogger CreateLogger(string categoryName)
+                => this.loggers.GetOrAdd(categoryName, this.CreateLoggerImplementation);
 
-		/// <summary>
-		/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-		/// </summary>
-		public void Dispose()
-		{
-			this.Dispose(true);
-			GC.SuppressFinalize(this);
-		}
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
 
-		/// <summary>
-		/// Releases unmanaged and - optionally - managed resources.
-		/// </summary>
-		/// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-		protected virtual void Dispose(bool disposing)
-		{
-			if (disposing)
-			{
-				return;
-			}
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                return;
+            }
 
-			this.loggers.Clear();
-		}
+            this.loggers.Clear();
+        }
 
-		/// <summary>
-		/// Rewrites the information of the node specified by xpath expression.
-		/// </summary>
-		/// <param name="configXml">The log4net config in xml.</param>
-		/// <param name="configurationSection">The configuration section.</param>
-		/// <returns>The xml configuration with overwritten  nodes if any</returns>
-		private static XmlDocument UpdateNodesWithAdditionalConfiguration(XmlDocument configXml, IConfigurationSection configurationSection)
-		{
-			var configXDoc = configXml.ToXDocument();
-			var additionalConfig = configurationSection.ConvertToDictionary();
-			foreach (string xpath in additionalConfig.Keys)
-			{
-				var node = configXDoc.XPathSelectElement(xpath);
-				if (node != null)
-				{
-					var nodeInfo = additionalConfig[xpath];
-					if (nodeInfo.NodeContent != null)
-					{
-						node.Value = nodeInfo.NodeContent;
-					}
+        /// <summary>
+        /// Rewrites the information of the node specified by xpath expression.
+        /// </summary>
+        /// <param name="configXml">The log4net config in xml.</param>
+        /// <param name="configurationSection">The configuration section.</param>
+        /// <returns>The xml configuration with overwritten  nodes if any</returns>
+        private static XmlDocument UpdateNodesWithAdditionalConfiguration(XmlDocument configXml, IConfigurationSection configurationSection)
+        {
+            var configXDoc = configXml.ToXDocument();
+            var additionalConfig = configurationSection.ConvertToNodesInfo();
+            foreach (var nodeInfo in additionalConfig)
+            {
+                var node = configXDoc.XPathSelectElement(nodeInfo.XPath);
+                if (node != null)
+                {
+                    if (nodeInfo.NodeContent != null)
+                    {
+                        node.Value = nodeInfo.NodeContent;
+                    }
 
-					AddOrUpdateAttributes(node, nodeInfo);
-				}
-			}
+                    AddOrUpdateAttributes(node, nodeInfo);
+                }
+            }
 
-			return configXDoc.ToXmlDocument();
-		}
+            return configXDoc.ToXmlDocument();
+        }
 
-		/// <summary>
-		/// Adds or updates the attributes specified in the node information.
-		/// </summary>
-		/// <param name="node">The node.</param>
-		/// <param name="nodeInfo">The node information.</param>
-		private static void AddOrUpdateAttributes(XElement node, NodeInfo nodeInfo)
-		{
-			foreach (var attribute in nodeInfo.Attributes)
-			{
-				var nodeAttribute = node.Attribute(attribute.Key);
-				if (nodeAttribute != null)
-				{
-					nodeAttribute.Value = attribute.Value;
-				}
-				else
-				{
-					node.SetAttributeValue(attribute.Key, attribute.Value);
-				}
-			}
-		}
+        /// <summary>
+        /// Adds or updates the attributes specified in the node information.
+        /// </summary>
+        /// <param name="node">The node.</param>
+        /// <param name="nodeInfo">The node information.</param>
+        private static void AddOrUpdateAttributes(XElement node, NodeInfo nodeInfo)
+        {
+            foreach (var attribute in nodeInfo.Attributes)
+            {
+                var nodeAttribute = node.Attribute(attribute.Key);
+                if (nodeAttribute != null)
+                {
+                    nodeAttribute.Value = attribute.Value;
+                }
+                else
+                {
+                    node.SetAttributeValue(attribute.Key, attribute.Value);
+                }
+            }
+        }
 
-		/// <summary>
-		/// Parses log4net config file.
-		/// </summary>
-		/// <param name="filename">The filename.</param>
-		/// <returns>The <see cref="XmlElement"/> with the log4net XML element.</returns>
-		private static XmlDocument ParseLog4NetConfigFile(string filename)
-		{
-			using (FileStream fp = File.OpenRead(filename))
-			{
-				var settings = new XmlReaderSettings
-				{
-					DtdProcessing = DtdProcessing.Prohibit
-				};
+        /// <summary>
+        /// Parses log4net config file.
+        /// </summary>
+        /// <param name="filename">The filename.</param>
+        /// <returns>The <see cref="XmlElement"/> with the log4net XML element.</returns>
+        private static XmlDocument ParseLog4NetConfigFile(string filename)
+        {
+            using (FileStream fp = File.OpenRead(filename))
+            {
+                var settings = new XmlReaderSettings
+                {
+                    DtdProcessing = DtdProcessing.Prohibit
+                };
 
-				var log4netConfig = new XmlDocument();
-				using (var reader = XmlReader.Create(fp, settings))
-				{
-					log4netConfig.Load(reader);
-				}
+                var log4netConfig = new XmlDocument();
+                using (var reader = XmlReader.Create(fp, settings))
+                {
+                    log4netConfig.Load(reader);
+                }
 
-				return log4netConfig;
-			}
-		}
+                return log4netConfig;
+            }
+        }
 
-		/// <summary>
-		/// Tries to retrieve the assembly from a "Startup" type found in the stack trace.
-		/// </summary>
-		/// <returns>Null for NetCoreApp 1.1, otherwise, Assembly of Startup type if found in stack trace.</returns>
-		private static Assembly GetCallingAssemblyFromStartup()
-		{
+        /// <summary>
+        /// Tries to retrieve the assembly from a "Startup" type found in the stack trace.
+        /// </summary>
+        /// <returns>Null for NetCoreApp 1.1, otherwise, Assembly of Startup type if found in stack trace.</returns>
+        private static Assembly GetCallingAssemblyFromStartup()
+        {
 #if NETCOREAPP1_1
-			return null;
+            return null;
 #else
             var stackTrace = new System.Diagnostics.StackTrace(2);
 
@@ -233,14 +232,14 @@
 
             return null;
 #endif
-		}
+        }
 
-		/// <summary>
-		/// Creates the logger implementation.
-		/// </summary>
-		/// <param name="name">The name.</param>
-		/// <returns>The <see cref="Log4NetLogger"/> instance.</returns>
-		private Log4NetLogger CreateLoggerImplementation(string name)
-			=> new Log4NetLogger(this.loggerRepository.Name, name);
-	}
+        /// <summary>
+        /// Creates the logger implementation.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <returns>The <see cref="Log4NetLogger"/> instance.</returns>
+        private Log4NetLogger CreateLoggerImplementation(string name)
+            => new Log4NetLogger(this.loggerRepository.Name, name);
+    }
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProviderExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProviderExtensions.cs
@@ -1,34 +1,34 @@
 ﻿namespace Microsoft.Extensions.Logging
 {
-	using System;
-	using System.Reflection;
+    using System;
+    using System.Reflection;
 
-	using log4net;
+    using log4net;
 
-	/// <summary>
-	/// Log4Net provider extensions.
-	/// </summary>
-	public static class Log4NetProviderExtensions
-	{
-		/// <summary>
-		/// Creates a logger with the name of the given <see cref="TName"/> type.
-		/// </summary>
-		/// <typeparam name="TName">The type of the class to be used as name of the logger.</typeparam>
-		/// <param name="self">An ILoggerProvider instance.</param>
-		/// <returns>An instance of the <see cref="ILogger"/>.</returns>
-		public static ILogger CreateLogger<TName>(this ILoggerProvider self) where TName : class
-		{
-			if (self == null)
-			{
-				throw new ArgumentNullException(nameof(self));
-			}
+    /// <summary>
+    /// Log4Net provider extensions.
+    /// </summary>
+    public static class Log4NetProviderExtensions
+    {
+        /// <summary>
+        /// Creates a logger with the name of the given <see cref="TName"/> type.
+        /// </summary>
+        /// <typeparam name="TName">The type of the class to be used as name of the logger.</typeparam>
+        /// <param name="self">An ILoggerProvider instance.</param>
+        /// <returns>An instance of the <see cref="ILogger"/>.</returns>
+        public static ILogger CreateLogger<TName>(this ILoggerProvider self) where TName : class
+        {
+            if (self == null)
+            {
+                throw new ArgumentNullException(nameof(self));
+            }
 
-			if (!self.GetType().IsAssignableFrom(typeof(Log4NetProvider)))
-			{
-				throw new ArgumentOutOfRangeException(nameof(self), "The ILoggerProvider should be of type Log4NetProvider.");
-			}
+            if (!self.GetType().IsAssignableFrom(typeof(Log4NetProvider)))
+            {
+                throw new ArgumentOutOfRangeException(nameof(self), "The ILoggerProvider should be of type Log4NetProvider.");
+            }
 
-			return self.CreateLogger(typeof(TName).FullName);
-		}
-	}
+            return self.CreateLogger(typeof(TName).FullName);
+        }
+    }
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Microsoft.Extensions.Logging.Log4Net.AspNetCore.csproj
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Microsoft.Extensions.Logging.Log4Net.AspNetCore.csproj
@@ -36,7 +36,7 @@
 		<Version>2.2.0</Version>
 		<AssemblyVersion>2.2.0.0</AssemblyVersion>
 		<FileVersion>2.2.0.0</FileVersion>
-		<SignAssembly>false</SignAssembly>
+		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>Microsoft.Extensions.Logging.Log4Net.AspNetCoreKey.pfx</AssemblyOriginatorKeyFile>
 		<PackageLicenseUrl>https://github.com/huorswords/Microsoft.Extensions.Logging.Log4Net.AspNetCore/blob/master/LICENSE</PackageLicenseUrl>
 	</PropertyGroup>

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Microsoft.Extensions.Logging.Log4Net.AspNetCore.csproj
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Microsoft.Extensions.Logging.Log4Net.AspNetCore.csproj
@@ -29,14 +29,14 @@
 			- #32 - The AddLog4Net() method does not take log4net.config filename automatically
 			Fixed bug.
 
-			Special thanks to Toni Wenzel (@kastwey) by its contributions
+			Special thanks to Toni Wenzel (@twenzel) and Juanjo M (@kastwey) by its contributions
 		</PackageReleaseNotes>
 		<PackageProjectUrl>https://github.com/huorswords/Microsoft.Extensions.Logging.Log4Net.AspNetCore</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/huorswords/Microsoft.Extensions.Logging.Log4Net.AspNetCore</RepositoryUrl>
 		<Version>2.2.0</Version>
 		<AssemblyVersion>2.2.0.0</AssemblyVersion>
 		<FileVersion>2.2.0.0</FileVersion>
-		<SignAssembly>true</SignAssembly>
+		<SignAssembly>false</SignAssembly>
 		<AssemblyOriginatorKeyFile>Microsoft.Extensions.Logging.Log4Net.AspNetCoreKey.pfx</AssemblyOriginatorKeyFile>
 		<PackageLicenseUrl>https://github.com/huorswords/Microsoft.Extensions.Logging.Log4Net.AspNetCore/blob/master/LICENSE</PackageLicenseUrl>
 	</PropertyGroup>

--- a/src/Tests/Listeners/CustomTraceListener.cs
+++ b/src/Tests/Listeners/CustomTraceListener.cs
@@ -1,19 +1,19 @@
 ﻿namespace Tests.Listeners
 {
-	using System.Collections.Generic;
-	using System.Diagnostics;
+    using System.Collections.Generic;
+    using System.Diagnostics;
 
-	internal class CustomTraceListener : TraceListener
-	{
-		public CustomTraceListener()
-			=> this.Messages = new List<string>();
+    internal class CustomTraceListener : TraceListener
+    {
+        public CustomTraceListener()
+            => this.Messages = new List<string>();
 
-		public IList<string> Messages { get; set; }
+        public IList<string> Messages { get; set; }
 
-		public override void Write(string message)
-			=> this.Messages.Add(message);
+        public override void Write(string message)
+            => this.Messages.Add(message);
 
-		public override void WriteLine(string message)
-			=> this.Write(message);
-	}
+        public override void WriteLine(string message)
+            => this.Write(message);
+    }
 }

--- a/src/Tests/appsettings.json
+++ b/src/Tests/appsettings.json
@@ -1,9 +1,16 @@
 ﻿{
-	"Logging": {
-		"/log4net/appender[@name='RollingFile']/file": {
+	"Logging": [
+		{
+			"XPath": "/log4net/appender[@name='RollingFile']/file",
 			"attributes": {
 				"value": "overrided.log"
 			}
-		}
-	}
+		},
+			{
+				"XPath": "/log4net/appender[@name='RollingFile']/maximumFileSize",
+				"attributes": {
+					"value": "200KB"
+				}
+			}
+	]
 }


### PR DESCRIPTION
Changed Net Core configuration section structure. Now, the XPath expression is a property inside NodeInfo object, to avoid problems when overriding Net Core configurations with environment variables, due to invalid characters in the environment variable name.

```json
{
	"Logging": [
		{
			"XPath": "/log4net/appender[@name='RollingFile']/file",
			"attributes": {
				"value": "overrided.log"
			}
		},
			{
				"XPath": "/log4net/appender[@name='RollingFile']/maximumFileSize",
				"attributes": {
					"value": "200KB"
				}
			}
	]
}```
