### PR TITLE
Fixed a couple of bugs related to the net core configuration overwriting and added documentation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,45 @@ public class Startup
 </log4net>
 ```
 
+## Overwriting the native log4net xml configuration using the Net Core configuration system.
+
+Sometimes we might want to modify the value of an appender, for example, the file name of our log. This might be interesting if we want to use a different name for each environment deployed. To do this, this package includes the possibility of overwriting the information of a node or the attributes of that node using the Net Core configuration system.
+
+To do this, you will need to do the following:
+
+1. Create a section within your `AppSettings.json` file:
+
+  ```json
+"Log4net": [
+		{
+			"XPath": "/log4net/appender[@name='RollingFile']/file",
+			"attributes": {
+				"value": "overrided.log"
+			}
+		},
+		{
+			"XPath": "/log4net/appender[@name='RollingFile']/maximumFileSize",
+			"attributes": {
+				"value": "1024KB"
+			}
+		}
+	]
+```
+
+  As you can see, the section is an array. For each element of the array, an `XPath` key must be included, which will contain the XPath expression to find the node from which we want to overwrite its information.
+
+  The `Attributes` key will contain a list of all the attributes you want to overwrite. In our case, we will almost always add the attribute `value`, followed by the value we want that attribute to take.
+
+  The `NodeContent` key will contain the text to be included inside the node, removing any information that was previously on the original node.
+
+2. Change the call to `loggerFactory.AddLog4Net`. Add as the first parameter the name of your `log4net` configuration file, and specify, as the second parameter, an IConfigurationSection object containing the configuration section you added to your `AppSettings.json` file:
+
+  ```csharp
+        loggerFactory.AddLog4Net("log4net.config", Configuration.GetSection("Log4net"));
+  ```
+
+This way, the package will iterate for each XPath contained in the array, will check if there are any nodes within the XML file that match the expression, and will overwrite the attributes or content of that node, depending on what you have specified in the configuration section.
+
 ## Special thanks
 
 Thank you very much to all contributors & users by its collaboration, and specially to:

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
@@ -14,7 +14,7 @@
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
     using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Extensions;
-    
+
     /// <summary>
     /// The log4net provider class.
     /// </summary>
@@ -146,23 +146,28 @@
         /// <returns>The xml configuration with overwritten  nodes if any</returns>
         private static XmlDocument UpdateNodesWithAdditionalConfiguration(XmlDocument configXml, IConfigurationSection configurationSection)
         {
-            var configXDoc = configXml.ToXDocument();
             var additionalConfig = configurationSection.ConvertToNodesInfo();
-            foreach (var nodeInfo in additionalConfig)
+            if (additionalConfig != null)
             {
-                var node = configXDoc.XPathSelectElement(nodeInfo.XPath);
-                if (node != null)
+                var configXDoc = configXml.ToXDocument();
+                foreach (var nodeInfo in additionalConfig)
                 {
-                    if (nodeInfo.NodeContent != null)
+                    var node = configXDoc.XPathSelectElement(nodeInfo.XPath);
+                    if (node != null)
                     {
-                        node.Value = nodeInfo.NodeContent;
-                    }
+                        if (nodeInfo.NodeContent != null)
+                        {
+                            node.Value = nodeInfo.NodeContent;
+                        }
 
-                    AddOrUpdateAttributes(node, nodeInfo);
+                        AddOrUpdateAttributes(node, nodeInfo);
+                    }
                 }
+
+                return configXDoc.ToXmlDocument();
             }
 
-            return configXDoc.ToXmlDocument();
+            return configXml;
         }
 
         /// <summary>
@@ -172,16 +177,19 @@
         /// <param name="nodeInfo">The node information.</param>
         private static void AddOrUpdateAttributes(XElement node, NodeInfo nodeInfo)
         {
-            foreach (var attribute in nodeInfo.Attributes)
+            if (nodeInfo?.Attributes != null)
             {
-                var nodeAttribute = node.Attribute(attribute.Key);
-                if (nodeAttribute != null)
+                foreach (var attribute in nodeInfo.Attributes)
                 {
-                    nodeAttribute.Value = attribute.Value;
-                }
-                else
-                {
-                    node.SetAttributeValue(attribute.Key, attribute.Value);
+                    var nodeAttribute = node.Attribute(attribute.Key);
+                    if (nodeAttribute != null)
+                    {
+                        nodeAttribute.Value = attribute.Value;
+                    }
+                    else
+                    {
+                        node.SetAttributeValue(attribute.Key, attribute.Value);
+                    }
                 }
             }
         }

--- a/src/Tests/LoggerShould.cs
+++ b/src/Tests/LoggerShould.cs
@@ -1,83 +1,108 @@
 namespace Tests
 {
-	using System;
-	using System.Diagnostics;
-	using System.IO;
-	using System.Linq;
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
 
-	using Microsoft.Extensions.Configuration;
-	using Microsoft.Extensions.Logging;
-	using Microsoft.VisualStudio.TestTools.UnitTesting;
-	using Tests.Listeners;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Tests.Listeners;
 
-	[TestClass]
-	public class LoggerShould
-	{
-		private CustomTraceListener listener;
+    [TestClass]
+    public class LoggerShould
+    {
+        private CustomTraceListener listener;
 
-		[TestInitialize]
-		public void Setup()
-		{
-			this.listener = new CustomTraceListener();
-			Trace.Listeners.Add(listener);
-		}
+        [TestInitialize]
+        public void Setup()
+        {
+            this.listener = new CustomTraceListener();
+            Trace.Listeners.Add(listener);
+        }
 
-		[TestMethod]
-		public void ProviderShouldBeCreatedWithConfigurationSectionOverrides()
-		{
-			if (File.Exists("overrided.log"))
-			{
-				File.Delete("overrided.log");
-			}
+        [TestMethod]
+        public void ProviderShouldBeCreatedWithConfigurationSectionOverrides()
+        {
+            if (File.Exists("overrided.log"))
+            {
+                File.Delete("overrided.log");
+            }
 
-			var builder = new ConfigurationBuilder();
-			builder.SetBasePath(Directory.GetCurrentDirectory())
-				.AddJsonFile("appsettings.json");
-			var configuration = builder.Build();
-			var provider = new Log4NetProvider("log4net.config", configuration.GetSection("Logging"));
-			var logger = provider.CreateLogger("test");
-			logger.LogCritical("Test file creation");
+            var configuration = GetNetCoreConfiguration();
+            var provider = new Log4NetProvider("log4net.config", configuration.GetSection("Logging"));
+            var logger = provider.CreateLogger("test");
+            logger.LogCritical("Test file creation");
 
-			Assert.IsNotNull(provider);
-			Assert.IsTrue(File.Exists("overrided.log"));
-		}
+            Assert.IsNotNull(provider);
+            Assert.IsTrue(File.Exists("overrided.log"));
+        }
 
-		[TestMethod]
-		public void LogCriticalMessages()
-		{
-			var provider = new Log4NetProvider("log4net.config");
-			var logger = provider.CreateLogger("Test");
+        [TestMethod]
+        public void ProviderShouldBeCreatedWithoutCoreConfigOverridesIfConfigSectionDoesNotContainData()
+        {
+            if (File.Exists("example.log"))
+            {
+                File.Delete("example.log");
+            }
 
-			const string message = "A message";
-			logger.LogCritical(message);
+            var configuration = GetNetCoreConfiguration();
+            var provider = new Log4NetProvider("log4net.config", configuration.GetSection("LoggingEmpty"));
+            var logger = provider.CreateLogger("test");
+            logger.LogCritical("Test file creation");
 
-			Assert.AreEqual(1, this.listener.Messages.Count);
-			Assert.IsTrue(this.listener.Messages.Any(x => x.Contains(message)));
-		}
+            Assert.IsNotNull(provider);
+            Assert.IsTrue(File.Exists("example.log"));
+        }
 
-		[TestMethod]
-		public void UsePatternLayoutOnExceptions()
-		{
-			var provider = new Log4NetProvider("log4net.config");
-			var logger = provider.CreateLogger("Test");
 
-			try
-			{
-				ThrowException();
-			}
-			catch (Exception ex)
-			{
-				logger.LogCritical(10, ex, "Catched message");
-			}
+        [TestMethod]
+        public void LogCriticalMessages()
+        {
+            var provider = new Log4NetProvider("log4net.config");
+            var logger = provider.CreateLogger("Test");
 
-			Assert.AreEqual(1, this.listener.Messages.Count);
-			Assert.IsTrue(this.listener.Messages.Any(x => x.Contains("Catched message")));
-		}
+            const string message = "A message";
+            logger.LogCritical(message);
 
-		/// <summary>
-		/// Throws the exception, and have stacktrace to be tested by the ExceptionLayoutPattern.
-		/// </summary>
-		/// <exception cref="InvalidOperationException">A message</exception>
-		private static void ThrowException() => throw new InvalidOperationException("A message");
-	}
+            Assert.AreEqual(1, this.listener.Messages.Count);
+            Assert.IsTrue(this.listener.Messages.Any(x => x.Contains(message)));
+        }
+
+        [TestMethod]
+        public void UsePatternLayoutOnExceptions()
+        {
+            var provider = new Log4NetProvider("log4net.config");
+            var logger = provider.CreateLogger("Test");
+
+            try
+            {
+                ThrowException();
+            }
+            catch (Exception ex)
+            {
+                logger.LogCritical(10, ex, "Catched message");
+            }
+
+            Assert.AreEqual(1, this.listener.Messages.Count);
+            Assert.IsTrue(this.listener.Messages.Any(x => x.Contains("Catched message")));
+        }
+
+        /// <summary>
+        /// Throws the exception, and have stacktrace to be tested by the ExceptionLayoutPattern.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">A message</exception>
+        private static void ThrowException() => throw new InvalidOperationException("A message");
+
+        private static IConfigurationRoot GetNetCoreConfiguration()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json");
+            var configuration = builder.Build();
+            return configuration;
+        }
+
+    }
 }

--- a/src/Tests/appsettings.json
+++ b/src/Tests/appsettings.json
@@ -2,15 +2,19 @@
 	"Logging": [
 		{
 			"XPath": "/log4net/appender[@name='RollingFile']/file",
-			"attributes": {
+			"Attributes": {
 				"value": "overrided.log"
 			}
 		},
-			{
-				"XPath": "/log4net/appender[@name='RollingFile']/maximumFileSize",
-				"attributes": {
-					"value": "200KB"
-				}
+		{
+			"XPath": "/log4net/appender[@name='RollingFile']/maximumFileSize",
+			"Attributes": {
+				"value": "200KB"
 			}
-	]
+		},
+		{
+			"XPath": "/log4net/appender[@name='RollingFile']/file"
+		}
+	],
+	"LoggingEmpty": []
 }


### PR DESCRIPTION
Fixed a bug when the specified configuration section does not exists. It seems the method "GetConfigurationSection" of IConfigurationRoot returns a not null object, even when the section does not exists.
Fixed a bug when the "NodeInfo" does not contains attributes, only NodeContent.
Added documentation in the readme.md file about the possibility to overwrite Log4Net configuration elemens using the NetCore configuration system.