### PR TITLE
Enable Log4NetProviderOptions configuration

### DIFF
--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Extensions/IConfigurationSectionExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Extensions/IConfigurationSectionExtensions.cs
@@ -1,13 +1,15 @@
 ﻿namespace Microsoft.Extensions.Logging.Log4Net.AspNetCore.Extensions
 {
-    using System.Collections.Generic;
+	using System;
+	using System.Collections.Generic;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
 
-    /// <summary>
-    /// class containing extensions for IConfigurationSection interface.
-    /// </summary>
-    internal static class IConfigurationSectionExtensions
+	/// <summary>
+	/// class containing extensions for IConfigurationSection interface.
+	/// </summary>
+	[Obsolete("To be removed on next releases")]
+	internal static class IConfigurationSectionExtensions
     {
         /// <summary>
         /// Converts IConfigurationSection to dictionary.
@@ -15,7 +17,8 @@
         /// <param name="configurationSection">The configuration section.</param>
         /// <returns>The dictionary</returns>
         /// <exception cref="ArgumentNullException">Throws if <paramref name="configurationSection"/> is null.</exception>
-        public static IEnumerable<NodeInfo> ConvertToNodesInfo(this IConfigurationSection configurationSection) =>
+        [Obsolete("To be removed on next releases")]
+		public static IEnumerable<NodeInfo> ToNodesInfo(this IConfigurationSection configurationSection) =>
             configurationSection.Get<IEnumerable<NodeInfo>>();
     }
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Extensions/LogExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Extensions/LogExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace Microsoft.Extensions.Logging.Log4Net.AspNetCore.Extensions
+{
+	using System;
+
+	using log4net;
+
+	/// <summary>
+	/// The <see cref="ILogExtensions"/> class.
+	/// </summary>
+	public static class LogExtensions
+	{
+		/// <summary>
+		/// Criticals the specified message.
+		/// </summary>
+		/// <param name="log">The log.</param>
+		/// <param name="message">The message.</param>
+		/// <param name="exception">The exception.</param>
+		public static void Critical(this ILog log, object message, Exception exception)
+			=> log.Logger.Log(null, log4net.Core.Level.Critical, message, exception);
+
+		/// <summary>
+		/// Traces the specified message.
+		/// </summary>
+		/// <param name="log">The log.</param>
+		/// <param name="message">The message.</param>
+		/// <param name="exception">The exception.</param>
+		public static void Trace(this ILog log, object message, Exception exception)
+			=> log.Logger.Log(null, log4net.Core.Level.Trace, message, exception);
+	}
+}

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetExtensions.cs
@@ -1,69 +1,70 @@
 ﻿namespace Microsoft.Extensions.Logging
 {
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
+	using System;
+	using Microsoft.Extensions.Configuration;
+	using Microsoft.Extensions.DependencyInjection;
 
-    /// <summary>
-    /// The log4net extensions class.
-    /// </summary>
-    public static class Log4NetExtensions
-    {
-        /// <summary>
-        /// The default log4net config file name.
-        /// </summary>
-        private const string DefaultLog4NetConfigFile = "log4net.config";
+	/// <summary>
+	/// The log4net extensions class.
+	/// </summary>
+	public static class Log4NetExtensions
+	{
+		/// <summary>
+		/// Adds the log4net.
+		/// </summary>
+		/// <param name="factory">The factory.</param>
+		/// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
+		public static ILoggerFactory AddLog4Net(this ILoggerFactory factory)
+			=> factory.AddLog4Net(new Log4NetProviderOptions());
 
-        /// <summary>
-        /// Adds the log4 net.
-        /// </summary>
-        /// <param name="factory">The factory.</param>
-        /// <param name="log4NetConfigFile">The log4 net configuration file.</param>
-        /// <param name="watch">if set to <c>true</c> [watch].</param>
-        /// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
-        public static ILoggerFactory AddLog4Net(
-            this ILoggerFactory factory,
-            string log4NetConfigFile,
-            bool watch)
-        {
-            factory.AddProvider(new Log4NetProvider(log4NetConfigFile, watch));
-            return factory;
-        }
+		/// <summary>
+		/// Adds the log4net.
+		/// </summary>
+		/// <param name="factory">The factory.</param>
+		/// <param name="log4NetConfigFile">The log4net Config File.</param>
+		/// <returns>The <see cref="ILoggerFactory"/> after adding the log4net provider.</returns>
+		public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, string log4NetConfigFile)
+			=> factory.AddLog4Net(log4NetConfigFile, false);
 
-        /// <summary>
-        /// Adds the log4net.
-        /// </summary>
-        /// <param name="factory">The factory.</param>
-        /// <param name="log4NetConfigFile">The log4 net configuration file.</param>
-        /// <param name="configurationSection">The configuration section.</param>
-        /// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
-        public static ILoggerFactory AddLog4Net(
-            this ILoggerFactory factory,
-            string log4NetConfigFile,
-            IConfigurationSection configurationSection)
-        {
-            factory.AddProvider(new Log4NetProvider(log4NetConfigFile, configurationSection));
-            return factory;
-        }
+		/// <summary>
+		/// Adds the log4net logging provider.
+		/// </summary>
+		/// <param name="factory">The factory.</param>
+		/// <param name="log4NetConfigFile">The log4 net configuration file.</param>
+		/// <param name="watch">if set to <c>true</c> [watch].</param>
+		/// <returns>The <see cref="ILoggerFactory"/> after adding the log4net provider.</returns>
+		public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, string log4NetConfigFile, bool watch)
+			=> factory.AddLog4Net(new Log4NetProviderOptions(log4NetConfigFile, watch));
 
-        /// <summary>
-        /// Adds the log4net.
-        /// </summary>
-        /// <param name="factory">The factory.</param>
-        /// <param name="log4NetConfigFile">The log4net Config File.</param>
-        /// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
-        public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, string log4NetConfigFile) =>
-            factory.AddLog4Net(log4NetConfigFile, false);
+		/// <summary>
+		/// Adds the log4net logging provider.
+		/// </summary>
+		/// <param name="factory">The logger factory.</param>
+		/// <param name="options">The options for log4net provider.</param>
+		/// <returns>The <see cref="ILoggerFactory"/> after adding the log4net provider.</returns>
+		public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, Log4NetProviderOptions options)
+		{
+			factory.AddProvider(new Log4NetProvider(options));
+			return factory;
+		}
 
-        /// <summary>
-        /// Adds the log4net.
-        /// </summary>
-        /// <param name="factory">The factory.</param>
-        /// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
-        public static ILoggerFactory AddLog4Net(this ILoggerFactory factory)
-        {
-            factory.AddLog4Net(DefaultLog4NetConfigFile);
-            return factory;
-        }
+		/// <summary>
+		/// Adds the log4net.
+		/// </summary>
+		/// <param name="factory">The factory.</param>
+		/// <param name="log4NetConfigFile">The log4 net configuration file.</param>
+		/// <param name="configurationSection">The configuration section.</param>
+		/// <returns>The <see cref="ILoggerFactory"/> with added Log4Net provider</returns>
+		[Obsolete("Use AddLog4Net(this ILoggingBuilder builder, Log4NetProviderOptions options) instead")]
+		public static ILoggerFactory AddLog4Net(
+			this ILoggerFactory factory,
+			string log4NetConfigFile,
+			IConfigurationSection configurationSection)
+		{
+			factory.AddProvider(new Log4NetProvider(log4NetConfigFile, configurationSection));
+			return factory;
+		}
+
 
 #if !NETCOREAPP1_1
         /// <summary>
@@ -73,8 +74,8 @@
         /// <returns>The <see ref="ILoggingBuilder" /> passed as parameter with the new provider registered.</returns>
         public static ILoggingBuilder AddLog4Net(this ILoggingBuilder builder)
         {
-            builder.Services.AddSingleton<ILoggerProvider>(new Log4NetProvider(DefaultLog4NetConfigFile));
-            return builder; 
+			var options = new Log4NetProviderOptions();
+			return builder.AddLog4Net(options);
         }
 
         /// <summary>
@@ -85,24 +86,9 @@
         /// <returns>The <see ref="ILoggingBuilder" /> passed as parameter with the new provider registered.</returns>
         public static ILoggingBuilder AddLog4Net(this ILoggingBuilder builder, string log4NetConfigFile)
         {
-            builder.Services.AddSingleton<ILoggerProvider>(new Log4NetProvider(log4NetConfigFile));
-            return builder; 
-        }
-
-        /// <summary>
-        /// Adds the log4net logging provider.
-        /// </summary>
-        /// <param name="builder">The logging builder instance.</param>
-        /// <param name="log4NetConfigFile">The log4net Config File.</param>
-        /// <param name="configurationSection">The configuration section.</param>
-        /// <returns>
-        /// The <see ref="ILoggingBuilder" /> passed as parameter with the new provider registered.
-        /// </returns>
-        public static ILoggingBuilder AddLog4Net(this ILoggingBuilder builder, string log4NetConfigFile, IConfigurationSection configurationSection)
-        {
-            builder.Services.AddSingleton<ILoggerProvider>(new Log4NetProvider(log4NetConfigFile, configurationSection));
-            return builder; 
-        }
+			var options = new Log4NetProviderOptions(log4NetConfigFile);
+			return builder.AddLog4Net(options);
+		}
 
         /// <summary>
         /// Adds the log4net logging provider.
@@ -115,9 +101,37 @@
         /// </returns>
         public static ILoggingBuilder AddLog4Net(this ILoggingBuilder builder, string log4NetConfigFile, bool watch)
         {
-            builder.Services.AddSingleton<ILoggerProvider>(new Log4NetProvider(log4NetConfigFile, watch));
+			var options = new Log4NetProviderOptions(log4NetConfigFile, watch);
+			return builder.AddLog4Net(options);
+		}
+
+        /// <summary>
+        /// Adds the log4net logging provider.
+        /// </summary>
+        /// <param name="builder">The logging builder instance.</param>
+        /// <param name="log4NetConfigFile">The log4net Config File.</param>
+        /// <returns>The <see ref="ILoggingBuilder" /> passed as parameter with the new provider registered.</returns>
+        public static ILoggingBuilder AddLog4Net(this ILoggingBuilder builder, Log4NetProviderOptions options)
+        {
+			builder.Services.AddSingleton<ILoggerProvider>(new Log4NetProvider(options));
+            return builder; 
+        }
+
+        /// <summary>
+        /// Adds the log4net logging provider.
+        /// </summary>
+        /// <param name="builder">The logging builder instance.</param>
+        /// <param name="log4NetConfigFile">The log4net Config File.</param>
+        /// <param name="configurationSection">The configuration section.</param>
+        /// <returns>
+        /// The <see ref="ILoggingBuilder" /> passed as parameter with the new provider registered.
+        /// </returns>
+		[Obsolete("Use AddLog4Net(this ILoggingBuilder builder, Log4NetProviderOptions options) instead")]
+        public static ILoggingBuilder AddLog4Net(this ILoggingBuilder builder, string log4NetConfigFile, IConfigurationSection configurationSection)
+        {
+            builder.Services.AddSingleton<ILoggerProvider>(new Log4NetProvider(log4NetConfigFile, configurationSection));
             return builder; 
         }
 #endif
-    }
+	}
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetLogger.cs
@@ -1,130 +1,161 @@
 ﻿namespace Microsoft.Extensions.Logging
 {
-    using System;
+	using System;
 
-    using log4net;
+	using log4net;
 
-    /// <summary>
-    /// The log4net logger class.
-    /// </summary>
-    public class Log4NetLogger : ILogger
-    {
-        /// <summary>
-        /// The log.
-        /// </summary>
-        private readonly ILog log;
+	using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Extensions;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Log4NetLogger"/> class.
-        /// </summary>
-        /// <param name="loggerRepository">The repository name.</param>
-        /// <param name="name">The logger's name.</param>
-        public Log4NetLogger(string loggerRepository, string name) 
-            => this.log = LogManager.GetLogger(loggerRepository, name);
+	/// <summary>
+	/// The log4net logger class.
+	/// </summary>
+	public class Log4NetLogger : ILogger
+	{
+		/// <summary>
+		/// The log.
+		/// </summary>
+		private readonly ILog log;
 
-        /// <summary>
-        /// Gets the name.
-        /// </summary>
-        public string Name
-        {
-            get
-            {
-                return this.log.Logger.Name;
-            }
-        }
+		/// <summary>
+		/// The provider options.
+		/// </summary>
+		private readonly Log4NetProviderOptions options;
 
-        /// <summary>
-        /// Begins a logical operation scope.
-        /// </summary>
-        /// <typeparam name="TState">The type of the state.</typeparam>
-        /// <param name="state">The identifier for the scope.</param>
-        /// <returns>
-        /// An IDisposable that ends the logical operation scope on dispose.
-        /// </returns>
-        public IDisposable BeginScope<TState>(TState state) 
-            => null;
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Log4NetLogger"/> class.
+		/// </summary>
+		/// <param name="loggerRepository">The repository name.</param>
+		/// <param name="name">The logger's name.</param>
+		[Obsolete("Use Log4NetLogger(Log4NetLoggerOptions) instead")]
+		public Log4NetLogger(string loggerRepository, string name)
+			=> this.log = LogManager.GetLogger(loggerRepository, name);
 
-        /// <summary>
-        /// Determines whether the logging level is enabled.
-        /// </summary>
-        /// <param name="logLevel">The log level.</param>
-        /// <returns>The <see cref="bool"/> value indicating whether the logging level is enabled.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">Throws when <paramref name="logLevel"/> is outside allowed range</exception>
-        public bool IsEnabled(LogLevel logLevel)
-        {
-            switch (logLevel)
-            {
-                case LogLevel.Critical:
-                    return this.log.IsFatalEnabled;
-                case LogLevel.Debug:
-                case LogLevel.Trace:
-                    return this.log.IsDebugEnabled;
-                case LogLevel.Error:
-                    return this.log.IsErrorEnabled;
-                case LogLevel.Information:
-                    return this.log.IsInfoEnabled;
-                case LogLevel.Warning:
-                    return this.log.IsWarnEnabled;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(logLevel));
-            }
-        }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Log4NetLogger"/> class.
+		/// </summary>
+		/// <param name="options">The log4net provider options.</param>
+		public Log4NetLogger(Log4NetProviderOptions options)
+		{
+			this.options = options ?? throw new ArgumentNullException(nameof(options));
+			this.log = LogManager.GetLogger(options.LoggerRepository, options.Name);
+		}
 
-        /// <summary>
-        /// Logs an exception into the log.
-        /// </summary>
-        /// <param name="logLevel">The log level.</param>
-        /// <param name="eventId">The event Id.</param>
-        /// <param name="state">The state.</param>
-        /// <param name="exception">The exception.</param>
-        /// <param name="formatter">The formatter.</param>
-        /// <typeparam name="TState">The type of the state.</typeparam>
-        /// <exception cref="ArgumentNullException">Throws when the <paramref name="formatter"/> is null.</exception>
-        public void Log<TState>(
-            LogLevel logLevel,
-            EventId eventId,
-            TState state,
-            Exception exception,
-            Func<TState, Exception, string> formatter)
-        {
-            if (!this.IsEnabled(logLevel))
-            {
-                return;
-            }
+		/// <summary>
+		/// Gets the name.
+		/// </summary>
+		public string Name
+			=> this.log.Logger.Name;
 
-            if (formatter == null)
-            {
-                throw new ArgumentNullException(nameof(formatter));
-            }
+		/// <summary>
+		/// Begins a logical operation scope.
+		/// </summary>
+		/// <typeparam name="TState">The type of the state.</typeparam>
+		/// <param name="state">The identifier for the scope.</param>
+		/// <returns>
+		/// An IDisposable that ends the logical operation scope on dispose.
+		/// </returns>
+		public IDisposable BeginScope<TState>(TState state)
+			=> null;
 
-            string message = formatter(state, exception);
-            if (!string.IsNullOrEmpty(message)
-                || exception != null)
-            {
-                switch (logLevel)
-                {
-                    case LogLevel.Critical:
-                        this.log.Fatal(message, exception);
-                        break;
-                    case LogLevel.Debug:
-                    case LogLevel.Trace:
-                        this.log.Debug(message, exception);
-                        break;
-                    case LogLevel.Error:
-                        this.log.Error(message, exception);
-                        break;
-                    case LogLevel.Information:
-                        this.log.Info(message, exception);
-                        break;
-                    case LogLevel.Warning:
-                        this.log.Warn(message, exception);
-                        break;
-                    default:
-                        this.log.Warn($"Encountered unknown log level {logLevel}, writing out as Info.");
-                        this.log.Info(message, exception);
-                        break;
-                }
-            }
-        }
-    }
+		/// <summary>
+		/// Determines whether the logging level is enabled.
+		/// </summary>
+		/// <param name="logLevel">The log level.</param>
+		/// <returns>The <see cref="bool"/> value indicating whether the logging level is enabled.</returns>
+		/// <exception cref="ArgumentOutOfRangeException">Throws when <paramref name="logLevel"/> is outside allowed range</exception>
+		public bool IsEnabled(LogLevel logLevel)
+		{
+			switch (logLevel)
+			{
+				case LogLevel.Critical:
+					return this.log.IsFatalEnabled;
+				case LogLevel.Debug:
+				case LogLevel.Trace:
+					return this.log.IsDebugEnabled;
+				case LogLevel.Error:
+					return this.log.IsErrorEnabled;
+				case LogLevel.Information:
+					return this.log.IsInfoEnabled;
+				case LogLevel.Warning:
+					return this.log.IsWarnEnabled;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(logLevel));
+			}
+		}
+
+		/// <summary>
+		/// Logs an exception into the log.
+		/// </summary>
+		/// <param name="logLevel">The log level.</param>
+		/// <param name="eventId">The event Id.</param>
+		/// <param name="state">The state.</param>
+		/// <param name="exception">The exception.</param>
+		/// <param name="formatter">The formatter.</param>
+		/// <typeparam name="TState">The type of the state.</typeparam>
+		/// <exception cref="ArgumentNullException">Throws when the <paramref name="formatter"/> is null.</exception>
+		public void Log<TState>(
+			LogLevel logLevel,
+			EventId eventId,
+			TState state,
+			Exception exception,
+			Func<TState, Exception, string> formatter)
+		{
+			if (!this.IsEnabled(logLevel))
+			{
+				return;
+			}
+
+			if (formatter == null)
+			{
+				throw new ArgumentNullException(nameof(formatter));
+			}
+
+			string message = formatter(state, exception);
+			if (!string.IsNullOrEmpty(message)
+				|| exception != null)
+			{
+				switch (logLevel)
+				{
+					case LogLevel.Critical:
+						string overrideCriticalLevelWith = options.OverrideCriticalLevelWith;
+						if (!string.IsNullOrEmpty(overrideCriticalLevelWith)
+							&& overrideCriticalLevelWith.Equals(LogLevel.Critical.ToString(), StringComparison.OrdinalIgnoreCase))
+						{
+							this.log.Critical(message, exception);
+						}
+						else
+						{
+							this.log.Fatal(message, exception);
+						}
+
+						break;
+
+					case LogLevel.Debug:
+						this.log.Debug(message, exception);
+						break;
+
+					case LogLevel.Error:
+						this.log.Error(message, exception);
+						break;
+
+					case LogLevel.Information:
+						this.log.Info(message, exception);
+						break;
+
+					case LogLevel.Warning:
+						this.log.Warn(message, exception);
+						break;
+
+					case LogLevel.Trace:
+						this.log.Trace(message, exception);
+						break;
+
+					default:
+						this.log.Warn($"Encountered unknown log level {logLevel}, writing out as Info.");
+						this.log.Info(message, exception);
+						break;
+				}
+			}
+		}
+	}
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProviderOptions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProviderOptions.cs
@@ -1,0 +1,78 @@
+﻿namespace Microsoft.Extensions.Logging
+{
+	using System.Collections.Generic;
+
+	using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
+
+	/// <summary>
+	/// The log4Net provider options.
+	/// </summary>
+	public sealed class Log4NetProviderOptions
+	{
+		/// <summary>
+		/// The default log4 net file name
+		/// </summary>
+		private const string DefaultLog4NetFileName = "log4net.config";
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Log4NetProviderOptions"/> class.
+		/// </summary>
+		public Log4NetProviderOptions()
+			: this(DefaultLog4NetFileName)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Log4NetProviderOptions"/> class.
+		/// </summary>
+		/// <param name="log4NetConfigFileName">Name of the log4 net configuration file.</param>
+		public Log4NetProviderOptions(string log4NetConfigFileName)
+			: this(log4NetConfigFileName, false)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Log4NetProviderOptions"/> class.
+		/// </summary>
+		/// <param name="log4NetConfigFileName">Name of the log4net configuration file.</param>
+		public Log4NetProviderOptions(string log4NetConfigFileName, bool watch)
+		{
+			this.Log4NetConfigFileName = log4NetConfigFileName;
+			this.Watch = watch;
+
+			this.OverrideCriticalLevelWith = string.Empty;
+			this.Name = string.Empty;
+			this.PropertyOverrides = new List<NodeInfo>();
+		}
+
+		/// <summary>
+		/// Gets or sets the name.
+		/// </summary>
+		public string Name { get; set; }
+
+		/// <summary>
+		/// Gets or sets the name of the log file.
+		/// </summary>
+		public string Log4NetConfigFileName { get; set; }
+
+		/// <summary>
+		/// Gets or sets the logger repository.
+		/// </summary>
+		public string LoggerRepository { get; set; }
+
+		/// <summary>
+		/// Gets or sets the level value that should be used to override default's critical level.
+		/// </summary>
+		public string OverrideCriticalLevelWith { get; set; }
+
+		/// <summary>
+		/// Gets or sets the property overrides.
+		/// </summary>
+		public List<NodeInfo> PropertyOverrides { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="Log4NetProviderOptions"/> is watch.
+		/// </summary>
+		public bool Watch { get; set; }
+	}
+}

--- a/src/NetCoreApp1.Tests/LoggerShould.cs
+++ b/src/NetCoreApp1.Tests/LoggerShould.cs
@@ -24,6 +24,24 @@ namespace NetCore1.Tests
 		}
 
 		[TestMethod]
+		public void ProviderShouldBeCreatedWithOptions()
+		{
+			const string OverridOHLogFilePath = "overridOH.log";
+			if (File.Exists(OverridOHLogFilePath))
+			{
+				File.Delete(OverridOHLogFilePath);
+			}
+
+			var options = GetLog4NetProviderOptions();
+			var provider = new Log4NetProvider(options);
+			var logger = provider.CreateLogger();
+			logger.LogCritical("Test file creation");
+
+			Assert.IsNotNull(provider);
+			Assert.IsTrue(File.Exists(OverridOHLogFilePath));
+		}
+
+		[TestMethod]
 		public void ProviderShouldBeCreatedWithConfigurationSectionOverrides()
 		{
 			if (File.Exists("overrided.log"))
@@ -96,14 +114,31 @@ namespace NetCore1.Tests
 		/// <exception cref="InvalidOperationException">A message</exception>
 		private static void ThrowException() => throw new InvalidOperationException("A message");
 
+		/// <summary>
+		/// Gets the .Net Core configuration.
+		/// </summary>
+		/// <returns>The <see cref="IConfigurationRoot"/> of the appsettings.json file.</returns>
 		private static IConfigurationRoot GetNetCoreConfiguration()
+		{
+			var builder = new ConfigurationBuilder();
+			builder.SetBasePath(Directory.GetCurrentDirectory())
+				   .AddJsonFile("appsettings.json");
+			var configuration = builder.Build();
+			return configuration;
+		}
+
+		/// <summary>
+		/// Gets the log4net provider options.
+		/// </summary>
+		/// <returns></returns>
+		private static Log4NetProviderOptions GetLog4NetProviderOptions()
 		{
 			var builder = new ConfigurationBuilder();
 			builder.SetBasePath(Directory.GetCurrentDirectory())
 				.AddJsonFile("appsettings.json");
 			var configuration = builder.Build();
-			return configuration;
-		}
 
+			return configuration.GetSection("Log4NetCore").Get<Log4NetProviderOptions>();
+		}
 	}
 }

--- a/src/NetCoreApp1.Tests/appsettings.json
+++ b/src/NetCoreApp1.Tests/appsettings.json
@@ -1,4 +1,27 @@
 ﻿{
+	"Log4NetCore": {
+		"Name": "Test",
+		"LoggerRepository": "Fantastic",
+		"OverrideCriticalLevelWith": "Fatal",
+		"Watch": false,
+		"PropertyOverrides": [
+			{
+				"XPath": "/log4net/appender[@name='RollingFile']/file",
+				"Attributes": {
+					"Value": "overridOH.log"
+				}
+			},
+			{
+				"XPath": "/log4net/appender[@name='RollingFile']/maximumFileSize",
+				"Attributes": {
+					"Value": "200KB"
+				}
+			},
+			{
+				"XPath": "/log4net/appender[@name='RollingFile']/file"
+			}
+		]
+	},
 	"Logging": [
 		{
 			"XPath": "/log4net/appender[@name='RollingFile']/file",

--- a/src/Tests/LoggerShould.cs
+++ b/src/Tests/LoggerShould.cs
@@ -14,6 +14,8 @@ namespace NetCore2.Tests
 	[TestClass]
 	public class LoggerShould
 	{
+		private const string DefaultLog4NetConfigFileName = "log4net.config";
+
 		private CustomTraceListener listener;
 
 		[TestInitialize]
@@ -21,6 +23,56 @@ namespace NetCore2.Tests
 		{
 			this.listener = new CustomTraceListener();
 			Trace.Listeners.Add(listener);
+		}
+
+		[TestMethod]
+		public void ProviderShouldBeCreatedWithOptions()
+		{
+			const string OverridOHLogFilePath = "overridOH.log";
+			if (File.Exists(OverridOHLogFilePath))
+			{
+				File.Delete(OverridOHLogFilePath);
+			}
+
+			var options = GetLog4NetProviderOptions();
+			var provider = new Log4NetProvider(options);
+			var logger = provider.CreateLogger();
+			logger.LogCritical("Test file creation");
+
+			Assert.IsNotNull(provider);
+			Assert.IsTrue(File.Exists(OverridOHLogFilePath));
+		}
+
+		[TestMethod]
+		public void LogCriticalMessages()
+		{
+			var provider = new Log4NetProvider(DefaultLog4NetConfigFileName);
+			var logger = provider.CreateLogger("Test");
+
+			const string message = "A message";
+			logger.LogCritical(message);
+
+			Assert.AreEqual(1, this.listener.Messages.Count);
+			Assert.IsTrue(this.listener.Messages.Any(x => x.Contains(message)));
+		}
+
+		[TestMethod]
+		public void UsePatternLayoutOnExceptions()
+		{
+			var provider = new Log4NetProvider(DefaultLog4NetConfigFileName);
+			var logger = provider.CreateLogger("Test");
+
+			try
+			{
+				ThrowException();
+			}
+			catch (Exception ex)
+			{
+				logger.LogCritical(10, ex, "Catched message");
+			}
+
+			Assert.AreEqual(1, this.listener.Messages.Count);
+			Assert.IsTrue(this.listener.Messages.Any(x => x.Contains("Catched message")));
 		}
 
 		[TestMethod]
@@ -32,7 +84,7 @@ namespace NetCore2.Tests
 			}
 
 			var configuration = GetNetCoreConfiguration();
-			var provider = new Log4NetProvider("log4net.config", configuration.GetSection("Logging"));
+			var provider = new Log4NetProvider(DefaultLog4NetConfigFileName, configuration.GetSection("Logging"));
 			var logger = provider.CreateLogger("test");
 			logger.LogCritical("Test file creation");
 
@@ -49,7 +101,7 @@ namespace NetCore2.Tests
 			}
 
 			var configuration = GetNetCoreConfiguration();
-			var provider = new Log4NetProvider("log4net.config", configuration.GetSection("LoggingEmpty"));
+			var provider = new Log4NetProvider(DefaultLog4NetConfigFileName, configuration.GetSection("LoggingEmpty"));
 			var logger = provider.CreateLogger("test");
 			logger.LogCritical("Test file creation");
 
@@ -57,53 +109,27 @@ namespace NetCore2.Tests
 			Assert.IsTrue(File.Exists("example.log"));
 		}
 
-
-		[TestMethod]
-		public void LogCriticalMessages()
-		{
-			var provider = new Log4NetProvider("log4net.config");
-			var logger = provider.CreateLogger("Test");
-
-			const string message = "A message";
-			logger.LogCritical(message);
-
-			Assert.AreEqual(1, this.listener.Messages.Count);
-			Assert.IsTrue(this.listener.Messages.Any(x => x.Contains(message)));
-		}
-
-		[TestMethod]
-		public void UsePatternLayoutOnExceptions()
-		{
-			var provider = new Log4NetProvider("log4net.config");
-			var logger = provider.CreateLogger("Test");
-
-			try
-			{
-				ThrowException();
-			}
-			catch (Exception ex)
-			{
-				logger.LogCritical(10, ex, "Catched message");
-			}
-
-			Assert.AreEqual(1, this.listener.Messages.Count);
-			Assert.IsTrue(this.listener.Messages.Any(x => x.Contains("Catched message")));
-		}
-
 		/// <summary>
 		/// Throws the exception, and have stacktrace to be tested by the ExceptionLayoutPattern.
 		/// </summary>
 		/// <exception cref="InvalidOperationException">A message</exception>
-		private static void ThrowException() => throw new InvalidOperationException("A message");
+		private static void ThrowException()
+			=> throw new InvalidOperationException("A message");
 
 		private static IConfigurationRoot GetNetCoreConfiguration()
-		{
-			var builder = new ConfigurationBuilder();
-			builder.SetBasePath(Directory.GetCurrentDirectory())
-				.AddJsonFile("appsettings.json");
-			var configuration = builder.Build();
-			return configuration;
-		}
+			=> new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory())
+										 .AddJsonFile("appsettings.json")
+										 .Build();
 
+		/// <summary>
+		/// Gets the log4net provider options.
+		/// </summary>
+		/// <returns></returns>
+		private static Log4NetProviderOptions GetLog4NetProviderOptions()
+			=> new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory())
+										 .AddJsonFile("appsettings.json")
+										 .Build()
+										 .GetSection("Log4NetCore")
+										 .Get<Log4NetProviderOptions>();
 	}
 }

--- a/src/Tests/appsettings.json
+++ b/src/Tests/appsettings.json
@@ -1,4 +1,27 @@
 ﻿{
+	"Log4NetCore": {
+		"Name": "Test",
+		"LoggerRepository": "Fantastic",
+		"OverrideCriticalLevelWith": "Fatal",
+		"Watch": false,
+		"PropertyOverrides": [
+			{
+				"XPath": "/log4net/appender[@name='RollingFile']/file",
+				"Attributes": {
+					"Value": "overridOH.log"
+				}
+			},
+			{
+				"XPath": "/log4net/appender[@name='RollingFile']/maximumFileSize",
+				"Attributes": {
+					"Value": "200KB"
+				}
+			},
+			{
+				"XPath": "/log4net/appender[@name='RollingFile']/file"
+			}
+		]
+	},
 	"Logging": [
 		{
 			"XPath": "/log4net/appender[@name='RollingFile']/file",


### PR DESCRIPTION
After the change, the developer will be able to configure the log4net
provider within a class named Log4NetProviderOptions.

This class is intented to allow the developer configure properties as:
- The logger default name.
- The logger repository name.
- The Log4Net.config file name / path.
- The log4net property override collection, to allow configure the
log4net file values on start through appsettings.json or environment
variables.
- The watch flag to be watching the log4net config file.
- The OverrideCriticalLevelWith, that allows:
  a) Critical - Sets the logger to use the native Critical level.
  b) Anything else - Sets the logger to use the Fatal level when
  critical is registered.

This commit solves #44