### PR TITLE
Let user of library decide if log4net should be configured from the outside 

### DIFF
--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
@@ -88,11 +88,16 @@
 			}
 			else
 			{
-				this.loggerRepository = LogManager.CreateRepository(
-					options.LoggerRepository,
-					typeof(log4net.Repository.Hierarchy.Hierarchy));
+				this.loggerRepository = LogManager.GetRepository(options.LoggerRepository) ?? LogManager.CreateRepository(
+						options.LoggerRepository,
+						typeof(log4net.Repository.Hierarchy.Hierarchy));
 			}
 
+			if (options.ExternalConfigurationSetup)
+			{
+				return;
+			}
+			
 			string fileNamePath = options.Log4NetConfigFileName;
 			if (!Path.IsPathRooted(fileNamePath))
 			{

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProviderOptions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProviderOptions.cs
@@ -80,5 +80,10 @@
         /// Gets or sets the scope factory.
         /// </summary>
         public Log4NetScopeFactory ScopeFactory { get; set; }
-    }
+
+        /// <summary>
+        /// Let user setup log4net externally
+        /// </summary>
+        public bool ExternalConfigurationSetup { get; set; }
+	}
 }

--- a/src/NetCoreApp1.Tests/Log4NetProviderExtensionsShould.cs
+++ b/src/NetCoreApp1.Tests/Log4NetProviderExtensionsShould.cs
@@ -1,5 +1,9 @@
-﻿namespace NetCore1.Tests
+﻿namespace NetCoreApp1.Tests
 {
+	using System.Reflection;
+	using log4net;
+	using log4net.Core;
+	using log4net.Repository.Hierarchy;
 	using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Extensions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -7,6 +11,12 @@
 	[TestClass]
 	public class Log4NetProviderExtensionsShould
 	{
+		[TestCleanup]
+		public void Cleanup()
+		{
+			LoggerManager.RepositorySelector = new DefaultRepositorySelector(typeof(Hierarchy));
+		}
+		
 		[TestMethod]
 		public void CreateLoggerWithTypeName()
 		{
@@ -16,6 +26,40 @@
 
 			Assert.IsNotNull(logger);
 			Assert.AreEqual(typeof(Log4NetProviderExtensionsShould).FullName, logger.Name);
+		}
+
+		[TestMethod]
+		public void WhenLoggerShouldBeExternallyConfigured_RepositoryIsNotConfigured()
+		{
+			LogManager.ResetConfiguration(Assembly.GetEntryAssembly());
+			
+			new Log4NetProvider(new Log4NetProviderOptions
+			{
+				ExternalConfigurationSetup = true
+			});
+
+			var repository = LogManager.GetRepository(Assembly.GetEntryAssembly());
+			Assert.IsFalse(repository.Configured);
+		}
+		
+		[TestMethod]
+		public void WhenLoggerShouldNotBeExternallyConfigured_RepositoryIsConfigured()
+		{
+			new Log4NetProvider(new Log4NetProviderOptions());
+
+			var repository = LogManager.GetRepository(Assembly.GetEntryAssembly());
+			Assert.IsTrue(repository.Configured);
+		}
+		
+		[TestMethod]
+		public void WhenRepositoryNameIsGivenButRepositoryIsAlreadyCreated_ProviderUsesAlreadyCreatedRepository()
+		{
+			LogManager.CreateRepository("abc");
+			
+			new Log4NetProvider(new Log4NetProviderOptions
+			{
+				LoggerRepository = "abc"
+			});
 		}
 	}
 }

--- a/src/NetCoreApp21.Tests/Log4NetProviderExtensionsShould.cs
+++ b/src/NetCoreApp21.Tests/Log4NetProviderExtensionsShould.cs
@@ -1,5 +1,11 @@
-﻿namespace NetCore2.Tests
+﻿
+
+namespace NetCoreApp21.Tests
 {
+	using System.Reflection;
+	using log4net;
+	using log4net.Core;
+	using log4net.Repository.Hierarchy;
 	using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Extensions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -7,6 +13,12 @@
 	[TestClass]
 	public class Log4NetProviderExtensionsShould
 	{
+		[TestCleanup]
+		public void Cleanup()
+		{
+			LoggerManager.RepositorySelector = new DefaultRepositorySelector(typeof(Hierarchy));
+		}
+		
 		[TestMethod]
 		public void CreateLoggerWithTypeName()
 		{
@@ -16,6 +28,40 @@
 
 			Assert.IsNotNull(logger);
 			Assert.AreEqual(typeof(Log4NetProviderExtensionsShould).FullName, logger.Name);
+		}
+
+		[TestMethod]
+		public void WhenLoggerShouldBeExternallyConfigured_RepositoryIsNotConfigured()
+		{
+			LogManager.ResetConfiguration(Assembly.GetEntryAssembly());
+			
+			new Log4NetProvider(new Log4NetProviderOptions
+			{
+				ExternalConfigurationSetup = true
+			});
+
+			var repository = LogManager.GetRepository(Assembly.GetEntryAssembly());
+			Assert.IsFalse(repository.Configured);
+		}
+		
+		[TestMethod]
+		public void WhenLoggerShouldNotBeExternallyConfigured_RepositoryIsConfigured()
+		{
+			new Log4NetProvider(new Log4NetProviderOptions());
+
+			var repository = LogManager.GetRepository(Assembly.GetEntryAssembly());
+			Assert.IsTrue(repository.Configured);
+		}
+		
+		[TestMethod]
+		public void WhenRepositoryNameIsGivenButRepositoryIsAlreadyCreated_ProviderUsesAlreadyCreatedRepository()
+		{
+			LogManager.CreateRepository("abc");
+			
+			new Log4NetProvider(new Log4NetProviderOptions
+			{
+				LoggerRepository = "abc"
+			});
 		}
 	}
 }

--- a/src/Tests/Log4NetProviderExtensionsShould.cs
+++ b/src/Tests/Log4NetProviderExtensionsShould.cs
@@ -1,5 +1,9 @@
-﻿namespace NetCore2.Tests
+﻿namespace NetCoreApp2.Tests
 {
+	using System.Reflection;
+	using log4net;
+	using log4net.Core;
+	using log4net.Repository.Hierarchy;
 	using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Extensions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -7,6 +11,12 @@
 	[TestClass]
 	public class Log4NetProviderExtensionsShould
 	{
+		[TestCleanup]
+		public void Cleanup()
+		{
+			LoggerManager.RepositorySelector = new DefaultRepositorySelector(typeof(Hierarchy));
+		}
+		
 		[TestMethod]
 		public void CreateLoggerWithTypeName()
 		{
@@ -16,6 +26,40 @@
 
 			Assert.IsNotNull(logger);
 			Assert.AreEqual(typeof(Log4NetProviderExtensionsShould).FullName, logger.Name);
+		}
+
+		[TestMethod]
+		public void WhenLoggerShouldBeExternallyConfigured_RepositoryIsNotConfigured()
+		{
+			LogManager.ResetConfiguration(Assembly.GetEntryAssembly());
+			
+			new Log4NetProvider(new Log4NetProviderOptions
+			{
+				ExternalConfigurationSetup = true
+			});
+
+			var repository = LogManager.GetRepository(Assembly.GetEntryAssembly());
+			Assert.IsFalse(repository.Configured);
+		}
+		
+		[TestMethod]
+		public void WhenLoggerShouldNotBeExternallyConfigured_RepositoryIsConfigured()
+		{
+			new Log4NetProvider(new Log4NetProviderOptions());
+
+			var repository = LogManager.GetRepository(Assembly.GetEntryAssembly());
+			Assert.IsTrue(repository.Configured);
+		}
+		
+		[TestMethod]
+		public void WhenRepositoryNameIsGivenButRepositoryIsAlreadyCreated_ProviderUsesAlreadyCreatedRepository()
+		{
+			LogManager.CreateRepository("abc");
+			
+			new Log4NetProvider(new Log4NetProviderOptions
+			{
+				LoggerRepository = "abc"
+			});
 		}
 	}
 }


### PR DESCRIPTION
1. Let the user decide if the library should configure log4net or if it should be done from the outside.
2. If the user can configure log4net from the outside, then the library should not fail when log4net repository already exists. 