### PR TITLE
Bugfix/observe scope factory in options

### DIFF
--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetLogger.cs
@@ -153,6 +153,12 @@ namespace Microsoft.Extensions.Logging
             }
         }
 
+        /// <summary>
+        /// A get-only property for accessing the <see cref="Log4NetProviderOptions"/>
+        /// within the instance.
+        /// </summary>
+        internal Log4NetProviderOptions Options => this.options;
+
         private static void EnsureValidFormatter<TState>(Func<TState, Exception, string> formatter)
         {
             if (formatter == null)

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
@@ -241,16 +241,16 @@ namespace Microsoft.Extensions.Logging
         /// <returns>The <see cref="Log4NetLogger"/> instance.</returns>
         private Log4NetLogger CreateLoggerImplementation(string name)
         {
-            var options = new Log4NetProviderOptions
+            var loggerOptions = new Log4NetProviderOptions
             {
                 Name = name,
                 LoggerRepository = this.loggerRepository.Name,
                 OverrideCriticalLevelWith = this.options.OverrideCriticalLevelWith
             };
 
-            options.ScopeFactory = new Log4NetScopeFactory(new Log4NetScopeRegistry());
+            loggerOptions.ScopeFactory = new Log4NetScopeFactory(new Log4NetScopeRegistry());
 
-            return new Log4NetLogger(options);
+            return new Log4NetLogger(loggerOptions);
         }
 
         /// <summary>

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
@@ -245,10 +245,9 @@ namespace Microsoft.Extensions.Logging
             {
                 Name = name,
                 LoggerRepository = this.loggerRepository.Name,
-                OverrideCriticalLevelWith = this.options.OverrideCriticalLevelWith
+                OverrideCriticalLevelWith = this.options.OverrideCriticalLevelWith,
+                ScopeFactory = this.options.ScopeFactory ?? new Log4NetScopeFactory(new Log4NetScopeRegistry())
             };
-
-            loggerOptions.ScopeFactory = new Log4NetScopeFactory(new Log4NetScopeRegistry());
 
             return new Log4NetLogger(loggerOptions);
         }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 
 // Exposes internals to unit tests.
+[assembly: InternalsVisibleTo("NetCoreApp.v1_x.Tests")]
 [assembly: InternalsVisibleTo("Swords.Core.Tests")]

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Runtime.CompilerServices;
+
+// Exposes internals to unit tests.
+[assembly: InternalsVisibleTo("Swords.Core.Tests")]

--- a/src/Tests/NetCoreApp1.Tests/Log4NetProviderExtensionsShould.cs
+++ b/src/Tests/NetCoreApp1.Tests/Log4NetProviderExtensionsShould.cs
@@ -1,10 +1,11 @@
-﻿using System.Reflection;
-using log4net;
+﻿using log4net;
 using log4net.Core;
 using log4net.Repository.Hierarchy;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Extensions;
+using Microsoft.Extensions.Logging.Scope;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
 
 namespace NetCoreApp.v1_x.Tests
 {
@@ -72,5 +73,36 @@ namespace NetCoreApp.v1_x.Tests
 				LoggerRepository = "abc"
 			});
 		}
+
+        [TestMethod]
+        public void WhenScopeFactoryIsNullOnProviderOptions_ThenDefaultLog4NetScopeFactoryIsUsed()
+        {
+            var options = new Log4NetProviderOptions
+            {
+                ScopeFactory = null
+            };
+            var provider = new Log4NetProvider(options);
+
+            var logger = provider.CreateLogger("test") as Log4NetLogger;
+
+            Assert.IsNotNull(logger?.Options?.ScopeFactory, "Scope factory on logger's options should not be null.");
+        }
+
+        [TestMethod]
+        public void WhenScopeFactoryIsProvidedInProviderOptions_ThenLoggerUsesProvidedScopeFactory()
+        {
+            var expectedFactory = new Log4NetScopeFactory(new Log4NetScopeRegistry());
+            var options = new Log4NetProviderOptions
+            {
+                ScopeFactory = expectedFactory
+            };
+            var provider = new Log4NetProvider(options);
+
+            var logger = provider.CreateLogger("test") as Log4NetLogger;
+
+            Assert.IsNotNull(logger?.Options?.ScopeFactory, "Scope factory on logger's options should not be null.");
+            Assert.AreSame(expectedFactory, logger.Options.ScopeFactory,
+                "Scope factory on logger does not match factory from provider options.");
+        }
 	}
 }

--- a/src/Tests/NetCoreApp20.Tests/Log4NetProviderExtensionsShould.cs
+++ b/src/Tests/NetCoreApp20.Tests/Log4NetProviderExtensionsShould.cs
@@ -1,68 +1,9 @@
-﻿using log4net;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Extensions;
-
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Reflection;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace NetCoreApp.v2_0.Tests
 {
     [TestClass]
-    public class Log4NetProviderExtensionsShould
+    public class Log4NetProviderExtensionsShould : Swords.Core.Tests.Log4NetProviderExtensionsShould
     {
-        [TestMethod]
-        public void CreateLoggerWithTypeName()
-        {
-            var provider = new Log4NetProvider();
-            var logger = provider.CreateLogger<Log4NetProviderExtensionsShould>() as Log4NetLogger;
-
-            Assert.IsNotNull(logger);
-            Assert.AreEqual(typeof(Log4NetProviderExtensionsShould).FullName, logger.Name);
-        }
-
-        [TestMethod]
-        public void CreateDefaultLoggerWithoutTypeName()
-        {
-            var provider = new Log4NetProvider();
-
-            var logger = provider.CreateLogger() as Log4NetLogger;
-
-            Assert.IsNotNull(logger);
-            Assert.AreEqual(string.Empty, logger.Name);
-        }
-
-        [TestMethod]
-        public void WhenLoggerShouldBeExternallyConfigured_RepositoryIsNotConfigured()
-        {
-            LogManager.ResetConfiguration(Assembly.GetEntryAssembly());
-
-            new Log4NetProvider(new Log4NetProviderOptions
-            {
-                ExternalConfigurationSetup = true
-            });
-
-            var repository = LogManager.GetRepository(Assembly.GetEntryAssembly());
-            Assert.IsFalse(repository.Configured);
-        }
-
-        [TestMethod]
-        public void WhenLoggerShouldNotBeExternallyConfigured_RepositoryIsConfigured()
-        {
-            new Log4NetProvider(new Log4NetProviderOptions());
-
-            var repository = LogManager.GetRepository(Assembly.GetEntryAssembly());
-            Assert.IsTrue(repository.Configured);
-        }
-
-        [TestMethod]
-        public void WhenRepositoryNameIsGivenButRepositoryIsAlreadyCreated_ProviderUsesAlreadyCreatedRepository()
-        {
-            LogManager.CreateRepository("abc");
-
-            new Log4NetProvider(new Log4NetProviderOptions
-            {
-                LoggerRepository = "abc"
-            });
-        }
     }
 }

--- a/src/Tests/NetCoreApp20.Tests/NetCoreApp.v2_0.Tests.csproj
+++ b/src/Tests/NetCoreApp20.Tests/NetCoreApp.v2_0.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
@@ -18,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Microsoft.Extensions.Logging.Log4Net.AspNetCore\Microsoft.Extensions.Logging.Log4Net.AspNetCore.csproj" />
+    <ProjectReference Include="..\Swords.Core.Tests\Swords.Core.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/NetCoreApp21.Tests/Log4NetProviderExtensionsShould.cs
+++ b/src/Tests/NetCoreApp21.Tests/Log4NetProviderExtensionsShould.cs
@@ -1,68 +1,9 @@
-﻿using log4net;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Extensions;
-
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Reflection;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace NetCoreApp.v2_1.Tests
 {
     [TestClass]
-    public class Log4NetProviderExtensionsShould
+    public class Log4NetProviderExtensionsShould : Swords.Core.Tests.Log4NetProviderExtensionsShould
     {
-        [TestMethod]
-        public void CreateLoggerWithTypeName()
-        {
-            var provider = new Log4NetProvider();
-            var logger = provider.CreateLogger<Log4NetProviderExtensionsShould>() as Log4NetLogger;
-
-            Assert.IsNotNull(logger);
-            Assert.AreEqual(typeof(Log4NetProviderExtensionsShould).FullName, logger.Name);
-        }
-
-        [TestMethod]
-        public void CreateDefaultLoggerWithoutTypeName()
-        {
-            var provider = new Log4NetProvider();
-
-            var logger = provider.CreateLogger() as Log4NetLogger;
-
-            Assert.IsNotNull(logger);
-            Assert.AreEqual(string.Empty, logger.Name);
-        }
-
-        [TestMethod]
-        public void WhenLoggerShouldBeExternallyConfigured_RepositoryIsNotConfigured()
-        {
-            LogManager.ResetConfiguration(Assembly.GetEntryAssembly());
-
-            new Log4NetProvider(new Log4NetProviderOptions
-            {
-                ExternalConfigurationSetup = true
-            });
-
-            var repository = LogManager.GetRepository(Assembly.GetEntryAssembly());
-            Assert.IsFalse(repository.Configured);
-        }
-
-        [TestMethod]
-        public void WhenLoggerShouldNotBeExternallyConfigured_RepositoryIsConfigured()
-        {
-            new Log4NetProvider(new Log4NetProviderOptions());
-
-            var repository = LogManager.GetRepository(Assembly.GetEntryAssembly());
-            Assert.IsTrue(repository.Configured);
-        }
-
-        [TestMethod]
-        public void WhenRepositoryNameIsGivenButRepositoryIsAlreadyCreated_ProviderUsesAlreadyCreatedRepository()
-        {
-            LogManager.CreateRepository("abc");
-
-            new Log4NetProvider(new Log4NetProviderOptions
-            {
-                LoggerRepository = "abc"
-            });
-        }
     }
 }

--- a/src/Tests/NetCoreApp21.Tests/NetCoreApp.v2_1.Tests.csproj
+++ b/src/Tests/NetCoreApp21.Tests/NetCoreApp.v2_1.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
@@ -19,7 +20,7 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Microsoft.Extensions.Logging.Log4Net.AspNetCore\Microsoft.Extensions.Logging.Log4Net.AspNetCore.csproj" />
+    <ProjectReference Include="..\Swords.Core.Tests\Swords.Core.Tests.csproj" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/src/Tests/Swords.Core.Tests/Log4NetProviderExtensionsShould.cs
+++ b/src/Tests/Swords.Core.Tests/Log4NetProviderExtensionsShould.cs
@@ -1,7 +1,7 @@
 ﻿using log4net;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Extensions;
-
+using Microsoft.Extensions.Logging.Scope;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Reflection;
 
@@ -63,6 +63,37 @@ namespace Swords.Core.Tests
             {
                 LoggerRepository = "abc"
             });
+        }
+
+        [TestMethod]
+        public void WhenScopeFactoryIsNullOnProviderOptions_ThenDefaultLog4NetScopeFactoryIsUsed()
+        {
+            var options = new Log4NetProviderOptions
+            {
+                ScopeFactory = null
+            };
+            var provider = new Log4NetProvider(options);
+            
+            var logger = provider.CreateLogger("test") as Log4NetLogger;
+
+            Assert.IsNotNull(logger?.Options?.ScopeFactory, "Scope factory on logger's options should not be null.");
+        }
+
+        [TestMethod]
+        public void WhenScopeFactoryIsProvidedInProviderOptions_ThenLoggerUsesProvidedScopeFactory()
+        {
+            var expectedFactory = new Log4NetScopeFactory(new Log4NetScopeRegistry());
+            var options = new Log4NetProviderOptions
+            {
+                ScopeFactory = expectedFactory
+            };
+            var provider = new Log4NetProvider(options);
+
+            var logger = provider.CreateLogger("test") as Log4NetLogger;
+
+            Assert.IsNotNull(logger?.Options?.ScopeFactory, "Scope factory on logger's options should not be null.");
+            Assert.AreSame(expectedFactory, logger.Options.ScopeFactory,
+                "Scope factory on logger does not match factory from provider options.");
         }
     }
 }


### PR DESCRIPTION
Fixes #95 by using the `ScopeFactory` property provided in the `Log4NetProviderOptions` value provided during logging configuration.

#### Changes
* Included new tests to validate the behavior is working as expected.
    * Added an `internal` get-only property on the `Log4NetLogger` class to facilitate the unit testing