### PR TITLE
Add configurable factory for log4net LoggingEvents

### DIFF
--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Entities/MessageCandidate.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Entities/MessageCandidate.cs
@@ -2,29 +2,26 @@
 
 namespace Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities
 {
-    internal class MessageCandidate
+    /// <summary>
+    /// Represents a candidate for a log message that should be printed. This candidate will either be accepted or denied by the logger that is trying to print it.
+    /// </summary>
+    /// <typeparam name="TState">Type of the state that is used to format the error message.</typeparam>
+    public class MessageCandidate<TState>
     {
-        public MessageCandidate(LogLevel logLevel, object message, Exception exception)
+        public MessageCandidate(TState state, LogLevel logLevel, Exception exception, Func<TState, Exception, string> formatter)
         {
+            State = state;
             LogLevel = logLevel;
-            Message = message;
             Exception = exception;
+            Formatter = formatter;
         }
+
+        public TState State { get; }
 
         public LogLevel LogLevel { get; }
 
-        public object Message { get; }
-
         public Exception Exception { get; }
 
-        public bool IsValid()
-        {
-            if (Message is string text && Exception == null)
-            {
-                return !string.IsNullOrEmpty(text);
-            }
-
-            return Message != null || Exception != null;
-        }
+        public Func<TState, Exception, string> Formatter { get; }
     }
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Entities/MessageCandidate.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Entities/MessageCandidate.cs
@@ -8,20 +8,38 @@ namespace Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities
     /// <typeparam name="TState">Type of the state that is used to format the error message.</typeparam>
     public class MessageCandidate<TState>
     {
-        public MessageCandidate(TState state, LogLevel logLevel, Exception exception, Func<TState, Exception, string> formatter)
+        public MessageCandidate(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             State = state;
             LogLevel = logLevel;
+            EventId = eventId;
             Exception = exception;
             Formatter = formatter;
         }
 
-        public TState State { get; }
-
+        /// <summary>
+        /// The log level the message should be printed with.
+        /// </summary>
         public LogLevel LogLevel { get; }
 
+        /// <summary>
+        /// The event id of the message.
+        /// </summary>
+        public EventId EventId { get; }
+
+        /// <summary>
+        /// The message state. Can be provided to the formatter to generate the string representation of the error message.
+        /// </summary>
+        public TState State { get; }
+
+        /// <summary>
+        /// Exception that should be printed with the message. Null if the log message has no corrosponding exception.
+        /// </summary>
         public Exception Exception { get; }
 
+        /// <summary>
+        /// The message formatter. Can be called with the state and exception to generate the string representation of the error message.
+        /// </summary>
         public Func<TState, Exception, string> Formatter { get; }
     }
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/ILog4NetLogLevelTranslator.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/ILog4NetLogLevelTranslator.cs
@@ -1,0 +1,16 @@
+﻿namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Represents a log level translator between the different logging systems.
+    /// </summary>
+    public interface ILog4NetLogLevelTranslator
+    {
+        /// <summary>
+        /// Translates a <see cref="LogLevel"/> to a log4net <see cref="log4net.Core.Level"/> based on the provided options.
+        /// </summary>
+        /// <param name="logLevel">The log level to translate.</param>
+        /// <param name="options">The log4net provider options influencing the translation.</param>
+        /// <returns>The corresponding log level for log4net.</returns>
+        log4net.Core.Level TranslateLogLevel(LogLevel logLevel, Log4NetProviderOptions options);
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/ILog4NetLoggingEventFactory.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/ILog4NetLoggingEventFactory.cs
@@ -1,0 +1,21 @@
+﻿using log4net.Core;
+using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
+
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Represents a factory that creates the log4net <see cref="log4net.Core.LoggingEvent"/> from a <see cref="MessageCandidate{TState}"/>.
+    /// </summary>
+    public interface ILog4NetLoggingEventFactory
+    {
+        /// <summary>
+        /// Create the <see cref="log4net.Core.LoggingEvent"/>.
+        /// </summary>
+        /// <typeparam name="TState">Type of the state object that is used to format the log message.</typeparam>
+        /// <param name="messageCandidate">The message information that should be logged.</param>
+        /// <param name="logger">The logger the event is created for.</param>
+        /// <param name="options">The options of the log4net logging provider.</param>
+        /// <returns>A <see cref="log4net.Core.LoggingEvent"/> that is ready to be logged with the provided logger or null if the candidate should be dropped.</returns>
+        LoggingEvent CreateLoggingEvent<TState>(MessageCandidate<TState> messageCandidate, log4net.Core.ILogger logger, Log4NetProviderOptions options);
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetLogLevelTranslator.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetLogLevelTranslator.cs
@@ -1,0 +1,42 @@
+﻿using log4net.Core;
+using System;
+
+namespace Microsoft.Extensions.Logging
+{
+    /// <inheritdoc cref="ILog4NetLogLevelTranslator"/>
+    public sealed class Log4NetLogLevelTranslator : ILog4NetLogLevelTranslator
+    {
+        /// <inheritdoc/>
+        public Level TranslateLogLevel(LogLevel logLevel, Log4NetProviderOptions options)
+        {
+            Level log4NetLevel = null;
+            switch (logLevel)
+            {
+                case LogLevel.Critical:
+                    string overrideCriticalLevelWith = options.OverrideCriticalLevelWith;
+                    log4NetLevel = !string.IsNullOrEmpty(overrideCriticalLevelWith)
+                            && overrideCriticalLevelWith.Equals(LogLevel.Critical.ToString(), StringComparison.OrdinalIgnoreCase)
+                                ? Level.Critical
+                                : Level.Fatal;
+                    break;
+                case LogLevel.Debug:
+                    log4NetLevel = Level.Debug;
+                    break;
+                case LogLevel.Error:
+                    log4NetLevel = Level.Error;
+                    break;
+                case LogLevel.Information:
+                    log4NetLevel = Level.Info;
+                    break;
+                case LogLevel.Warning:
+                    log4NetLevel = Level.Warn;
+                    break;
+                case LogLevel.Trace:
+                    log4NetLevel = Level.Trace;
+                    break;
+            }
+
+            return log4NetLevel;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetLoggingEventFactory.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetLoggingEventFactory.cs
@@ -5,7 +5,7 @@ using System;
 namespace Microsoft.Extensions.Logging
 {
     /// <inheritdoc cref="ILog4NetLoggingEventFactory"/>
-    public class Log4NetLoggingEventFactory
+    public sealed class Log4NetLoggingEventFactory
         : ILog4NetLoggingEventFactory
     {
         /// <inheritdoc/>
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Logging
         {
             Type callerStackBoundaryDeclaringType = typeof(LoggerExtensions);
             string message = messageCandidate.Formatter(messageCandidate.State, messageCandidate.Exception);
-            Level logLevel = Log4NetLogger.SelectLevel(messageCandidate, options);
+            Level logLevel = options.LogLevelTranslator.TranslateLogLevel(messageCandidate.LogLevel, options);
 
             if (logLevel == null || (string.IsNullOrEmpty(message) && messageCandidate.Exception == null))
                 return null;

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetLoggingEventFactory.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetLoggingEventFactory.cs
@@ -1,0 +1,30 @@
+﻿using log4net.Core;
+using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
+using System;
+
+namespace Microsoft.Extensions.Logging
+{
+    /// <inheritdoc cref="ILog4NetLoggingEventFactory"/>
+    public class Log4NetLoggingEventFactory
+        : ILog4NetLoggingEventFactory
+    {
+        /// <inheritdoc/>
+        public LoggingEvent CreateLoggingEvent<TState>(MessageCandidate<TState> messageCandidate, log4net.Core.ILogger logger, Log4NetProviderOptions options)
+        {
+            Type callerStackBoundaryDeclaringType = typeof(LoggerExtensions);
+            string message = messageCandidate.Formatter(messageCandidate.State, messageCandidate.Exception);
+            Level logLevel = Log4NetLogger.SelectLevel(messageCandidate, options);
+
+            if (logLevel == null || (string.IsNullOrEmpty(message) && messageCandidate.Exception == null))
+                return null;
+
+            return new LoggingEvent(
+                callerStackBoundaryDeclaringType: callerStackBoundaryDeclaringType,
+                repository: logger.Repository,
+                loggerName: logger.Name,
+                level: logLevel,
+                message: message,
+                exception: messageCandidate.Exception);
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
@@ -1,6 +1,7 @@
 ﻿using log4net;
 using log4net.Config;
 using log4net.Repository;
+using Microsoft.Extensions.Logging.Log4Net.AspNetCore;
 using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
 using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Extensions;
 using Microsoft.Extensions.Logging.Scope;
@@ -244,7 +245,8 @@ namespace Microsoft.Extensions.Logging
                 Name = name,
                 LoggerRepository = this.loggerRepository.Name,
                 OverrideCriticalLevelWith = this.options.OverrideCriticalLevelWith,
-                ScopeFactory = this.options.ScopeFactory ?? new Log4NetScopeFactory(new Log4NetScopeRegistry())
+                ScopeFactory = this.options.ScopeFactory ?? new Log4NetScopeFactory(new Log4NetScopeRegistry()),
+                LoggingEventFactory = this.options.LoggingEventFactory ?? new Log4NetLoggingEventFactory(),
             };
 
             return new Log4NetLogger(loggerOptions);

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProvider.cs
@@ -247,6 +247,7 @@ namespace Microsoft.Extensions.Logging
                 OverrideCriticalLevelWith = this.options.OverrideCriticalLevelWith,
                 ScopeFactory = this.options.ScopeFactory ?? new Log4NetScopeFactory(new Log4NetScopeRegistry()),
                 LoggingEventFactory = this.options.LoggingEventFactory ?? new Log4NetLoggingEventFactory(),
+                LogLevelTranslator = this.options.LogLevelTranslator ?? new Log4NetLogLevelTranslator(),
             };
 
             return new Log4NetLogger(loggerOptions);

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProviderOptions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProviderOptions.cs
@@ -96,5 +96,10 @@ namespace Microsoft.Extensions.Logging
         /// Gets or sets the factory for the log4net <see cref="log4net.Core.LoggingEvent"/>."/>.
         /// </summary>
         public ILog4NetLoggingEventFactory LoggingEventFactory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the translator between the <see cref="LogLevel"/> and the log4net <see cref="log4net.Core.Level"/>.
+        /// </summary>
+        public ILog4NetLogLevelTranslator LogLevelTranslator { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProviderOptions.cs
+++ b/src/Microsoft.Extensions.Logging.Log4Net.AspNetCore/Log4NetProviderOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
+﻿using Microsoft.Extensions.Logging.Log4Net.AspNetCore;
+using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
 using Microsoft.Extensions.Logging.Scope;
 using System.Collections.Generic;
 
@@ -90,5 +91,10 @@ namespace Microsoft.Extensions.Logging
         /// Let user setup log4net from web.config / app.config.
         /// </summary>
         public bool UseWebOrAppConfig { get; set; }
+
+        /// <summary>
+        /// Gets or sets the factory for the log4net <see cref="log4net.Core.LoggingEvent"/>."/>.
+        /// </summary>
+        public ILog4NetLoggingEventFactory LoggingEventFactory { get; set; }
     }
 }

--- a/tests/Unit.Tests.Target.Net5/Fixtures/AppenderFixture.cs
+++ b/tests/Unit.Tests.Target.Net5/Fixtures/AppenderFixture.cs
@@ -104,6 +104,7 @@ namespace Unit.Tests.Target.Netcore31.Fixtures
                 LoggerRepository = RepositoryName,
                 Name = RepositoryName,
                 LoggingEventFactory = new Log4NetLoggingEventFactory(),
+                LogLevelTranslator = new Log4NetLogLevelTranslator(),
             };
 
             SetupLog4NetRepository(options);

--- a/tests/Unit.Tests.Target.Net5/Fixtures/AppenderFixture.cs
+++ b/tests/Unit.Tests.Target.Net5/Fixtures/AppenderFixture.cs
@@ -102,7 +102,8 @@ namespace Unit.Tests.Target.Netcore31.Fixtures
             {
                 Log4NetConfigFileName = GetLog4netFilePath(log4NetFile),
                 LoggerRepository = RepositoryName,
-                Name = RepositoryName
+                Name = RepositoryName,
+                LoggingEventFactory = new Log4NetLoggingEventFactory(),
             };
 
             SetupLog4NetRepository(options);

--- a/tests/Unit.Tests.Target.Net5/Log4NetProviderOptionsTests.cs
+++ b/tests/Unit.Tests.Target.Net5/Log4NetProviderOptionsTests.cs
@@ -22,6 +22,7 @@ namespace Unit.Tests.Target.Netcore31
             sut.ScopeFactory.Should().BeNull();
             sut.Watch.Should().BeFalse();
             sut.LoggingEventFactory.Should().BeNull();
+            sut.LogLevelTranslator.Should().BeNull();
         }
 
         [Fact]
@@ -40,6 +41,7 @@ namespace Unit.Tests.Target.Netcore31
             sut.ScopeFactory.Should().BeNull();
             sut.Watch.Should().BeFalse();
             sut.LoggingEventFactory.Should().BeNull();
+            sut.LogLevelTranslator.Should().BeNull();
         }
 
         [Fact]
@@ -58,6 +60,7 @@ namespace Unit.Tests.Target.Netcore31
             sut.ScopeFactory.Should().BeNull();
             sut.Watch.Should().BeTrue();
             sut.LoggingEventFactory.Should().BeNull();
+            sut.LogLevelTranslator.Should().BeNull();
         }
 
         [Fact]
@@ -78,6 +81,7 @@ namespace Unit.Tests.Target.Netcore31
             sut.Watch.Should().BeFalse();
             sut.UseWebOrAppConfig.Should().BeTrue();
             sut.LoggingEventFactory.Should().BeNull();
+            sut.LogLevelTranslator.Should().BeNull();
         }
 
         [Fact]
@@ -100,6 +104,30 @@ namespace Unit.Tests.Target.Netcore31
             sut.Watch.Should().BeFalse();
             sut.UseWebOrAppConfig.Should().BeFalse();
             sut.LoggingEventFactory.Should().Be(loggingEventFactory);
+            sut.LogLevelTranslator.Should().BeNull();
+        }
+
+        [Fact]
+        public void LogLevelTranslator_Should_BeEditable()
+        {
+            var logLevelTranslator = new Mock<ILog4NetLogLevelTranslator>().Object;
+
+            var sut = new Log4NetProviderOptions
+            {
+                LogLevelTranslator = logLevelTranslator
+            };
+
+            sut.ExternalConfigurationSetup.Should().BeFalse();
+            sut.Log4NetConfigFileName.Should().Be("log4net.config");
+            sut.LoggerRepository.Should().BeNull();
+            sut.Name.Should().BeEmpty();
+            sut.OverrideCriticalLevelWith.Should().Be("");
+            sut.PropertyOverrides.Should().BeEmpty();
+            sut.ScopeFactory.Should().BeNull();
+            sut.Watch.Should().BeFalse();
+            sut.UseWebOrAppConfig.Should().BeFalse();
+            sut.LoggingEventFactory.Should().BeNull();
+            sut.LogLevelTranslator.Should().Be(logLevelTranslator);
         }
     }
 }

--- a/tests/Unit.Tests.Target.Net5/Log4NetProviderOptionsTests.cs
+++ b/tests/Unit.Tests.Target.Net5/Log4NetProviderOptionsTests.cs
@@ -1,5 +1,7 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Log4Net.AspNetCore;
+using Moq;
 using Xunit;
 
 namespace Unit.Tests.Target.Netcore31
@@ -19,6 +21,7 @@ namespace Unit.Tests.Target.Netcore31
             sut.PropertyOverrides.Should().BeEmpty();
             sut.ScopeFactory.Should().BeNull();
             sut.Watch.Should().BeFalse();
+            sut.LoggingEventFactory.Should().BeNull();
         }
 
         [Fact]
@@ -36,6 +39,7 @@ namespace Unit.Tests.Target.Netcore31
             sut.PropertyOverrides.Should().BeEmpty();
             sut.ScopeFactory.Should().BeNull();
             sut.Watch.Should().BeFalse();
+            sut.LoggingEventFactory.Should().BeNull();
         }
 
         [Fact]
@@ -53,6 +57,7 @@ namespace Unit.Tests.Target.Netcore31
             sut.PropertyOverrides.Should().BeEmpty();
             sut.ScopeFactory.Should().BeNull();
             sut.Watch.Should().BeTrue();
+            sut.LoggingEventFactory.Should().BeNull();
         }
 
         [Fact]
@@ -72,6 +77,29 @@ namespace Unit.Tests.Target.Netcore31
             sut.ScopeFactory.Should().BeNull();
             sut.Watch.Should().BeFalse();
             sut.UseWebOrAppConfig.Should().BeTrue();
+            sut.LoggingEventFactory.Should().BeNull();
+        }
+
+        [Fact]
+        public void LoggingEventFactory_Should_BeEditable()
+        {
+            var loggingEventFactory = new Mock<ILog4NetLoggingEventFactory>().Object;
+
+            var sut = new Log4NetProviderOptions
+            {
+                LoggingEventFactory = loggingEventFactory
+            };
+
+            sut.ExternalConfigurationSetup.Should().BeFalse();
+            sut.Log4NetConfigFileName.Should().Be("log4net.config");
+            sut.LoggerRepository.Should().BeNull();
+            sut.Name.Should().BeEmpty();
+            sut.OverrideCriticalLevelWith.Should().Be("");
+            sut.PropertyOverrides.Should().BeEmpty();
+            sut.ScopeFactory.Should().BeNull();
+            sut.Watch.Should().BeFalse();
+            sut.UseWebOrAppConfig.Should().BeFalse();
+            sut.LoggingEventFactory.Should().Be(loggingEventFactory);
         }
     }
 }

--- a/tests/Unit.Tests.Target.Net5/Log4NetProviderTests.cs
+++ b/tests/Unit.Tests.Target.Net5/Log4NetProviderTests.cs
@@ -71,6 +71,43 @@ namespace Unit.Tests.Target.Netcore31
                                                  .And.Be(expectedFactory, "Scope factory on logger does not match factory from provider options.");
         }
 
+        [Fact]
+        public void WhenLoggingEventFactoryIsNullOnProviderOptions_ThenDefaultLog4NetLoggingEventFactoryIsUsed()
+        {
+            var options = new Log4NetProviderOptions
+            {
+                LoggingEventFactory = null
+            };
+
+            var sut = new Log4NetProvider(options);
+            var logger = sut.CreateLogger("test") as Log4NetLogger;
+
+            var internalOptions = GetInternalOptions(logger);
+
+            internalOptions.Should().NotBeNull();
+            internalOptions.LoggingEventFactory.Should().NotBeNull("a default LoggingEventFactory is needed to create LoggingEvents")
+                                                        .And.BeOfType<Log4NetLoggingEventFactory>("because this is the default factory type");
+        }
+
+        [Fact]
+        public void WhenLoggingEventFactoryIsProvidedInProviderOptions_ThenDefaultLog4NetLoggingEventFactoryIsUsed()
+        {
+            var expectedFactory = new Log4NetLoggingEventFactory();
+            var options = new Log4NetProviderOptions
+            {
+                LoggingEventFactory = expectedFactory
+            };
+
+            var sut = new Log4NetProvider(options);
+            var logger = sut.CreateLogger("test") as Log4NetLogger;
+
+            var internalOptions = GetInternalOptions(logger);
+
+            internalOptions.Should().NotBeNull();
+            internalOptions.LoggingEventFactory.Should().NotBeNull("a LoggingEventFactory was provided in the options")
+                                                        .And.Be(expectedFactory, "this LoggingEventFactory was provided in the options");
+        }
+
         private Log4NetProviderOptions GetInternalOptions(Log4NetLogger logger)
         {
             return logger.GetType()

--- a/tests/Unit.Tests.Target.Net5/Log4NetProviderTests.cs
+++ b/tests/Unit.Tests.Target.Net5/Log4NetProviderTests.cs
@@ -90,7 +90,7 @@ namespace Unit.Tests.Target.Netcore31
         }
 
         [Fact]
-        public void WhenLoggingEventFactoryIsProvidedInProviderOptions_ThenDefaultLog4NetLoggingEventFactoryIsUsed()
+        public void WhenLoggingEventFactoryIsProvidedInProviderOptions_ThenLoggerUsesProvidedLoggingEventFactory()
         {
             var expectedFactory = new Log4NetLoggingEventFactory();
             var options = new Log4NetProviderOptions
@@ -106,6 +106,43 @@ namespace Unit.Tests.Target.Netcore31
             internalOptions.Should().NotBeNull();
             internalOptions.LoggingEventFactory.Should().NotBeNull("a LoggingEventFactory was provided in the options")
                                                         .And.Be(expectedFactory, "this LoggingEventFactory was provided in the options");
+        }
+
+        [Fact]
+        public void WhenLogLevelTranslatorIsNullOnProviderOptions_ThenDefaultLog4NetLogLevelTranslatorIsUsed()
+        {
+            var options = new Log4NetProviderOptions
+            {
+                LogLevelTranslator = null
+            };
+
+            var sut = new Log4NetProvider(options);
+            var logger = sut.CreateLogger("test") as Log4NetLogger;
+
+            var internalOptions = GetInternalOptions(logger);
+
+            internalOptions.Should().NotBeNull();
+            internalOptions.LogLevelTranslator.Should().NotBeNull("a default LogLevelTranslator is needed to create LoggingEvents")
+                                                        .And.BeOfType<Log4NetLogLevelTranslator>("because this is the default translator type");
+        }
+
+        [Fact]
+        public void WhenLogLevelTranslatorIsProvidedInProviderOptions_ThenLoggerUsesProvidedLogLevelTranslator()
+        {
+            var expectedTranslator = new Log4NetLogLevelTranslator();
+            var options = new Log4NetProviderOptions
+            {
+                LogLevelTranslator = expectedTranslator
+            };
+
+            var sut = new Log4NetProvider(options);
+            var logger = sut.CreateLogger("test") as Log4NetLogger;
+
+            var internalOptions = GetInternalOptions(logger);
+
+            internalOptions.Should().NotBeNull();
+            internalOptions.LogLevelTranslator.Should().NotBeNull("a LogLevelTranslator was provided in the options")
+                                                        .And.Be(expectedTranslator, "this LogLevelTranslator was provided in the options");
         }
 
         private Log4NetProviderOptions GetInternalOptions(Log4NetLogger logger)


### PR DESCRIPTION
The Log4NetLoggingEventFactory will be used to create the logging events
provided to log4net. This allows for a greater control over the data
provided to the logging system and to extract aditional data from the
state that is used to format the message.

Fixes #109 

I haven't added an example to the Readme yet. I will do that if you are happy with the general API.

Also this commit has slightly different behaviour than before:

Previously `IsEnabled(LogLevel logLevel)` returned the activation status of `Level.Fatal` if `LogLevel.Critical` was provided, but `SelectLevel(MessageCandidate candidate)` returned the level `Level.Critical` or `Level.Fatal` based on the `Log4NetProviderOptions `. If that was intended behaviour I will of course change it back. 